### PR TITLE
Highlight methods in some forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Highlight "\`quoted-symbols\`  in docs strings like this."
    - This feature uses a nested markdown parser.
      If the parser is not available this feature should be silently disabled.
+- Highlight methods for `deftype`, `defrecord`, `defprotocol`, `reify` and `definterface`
+  forms ([#20](https://github.com/clojure-emacs/clojure-ts-mode/issues/20)).
 
 ## 0.1.5
 
@@ -29,7 +31,7 @@
 
 ## 0.1.2
 
-- Add a syntax table from clojure-mode. [712dc772fd38111c1e35fe60e4dbe7ac83032bd6](https://github.com/clojure-emacs/clojure-ts-mode/commit/712dc772fd38111c1e35fe60e4dbe7ac83032bd6). 
+- Add a syntax table from clojure-mode. [712dc772fd38111c1e35fe60e4dbe7ac83032bd6](https://github.com/clojure-emacs/clojure-ts-mode/commit/712dc772fd38111c1e35fe60e4dbe7ac83032bd6).
     - Better support for `thing-at-point` driven functionality.
     - Thank you @jasonjckn for this contribution.
 - Add 3 derived major modes [4dc853df16ba09d10dc3a648865e681679c17606](https://github.com/clojure-emacs/clojure-ts-mode/commit/4dc853df16ba09d10dc3a648865e681679c17606)

--- a/test/test.clj
+++ b/test/test.clj
@@ -29,7 +29,7 @@
 ;; examples of valid namespace definitions
 (comment
   (ns .validns)
- 
+
   (ns =validns)
   (ns .ValidNs=<>?+|?*.)
   (ns ValidNs<>?+|?*.b*ar.ba*z)
@@ -289,3 +289,44 @@ clojure.core/map
 
 (def ^Integer x 1)
 
+(comment
+  (defrecord TestRecord [field]
+    AutoCloseable
+    (close [this]
+      (.close this)))
+
+  (reify
+    AutoCloseable
+    (close [this] (.close this))
+
+    (another [this arg]
+      (implement this arg)))
+
+  (definterface MyInterface
+    (^String name [])
+    (^double mass []))
+
+  (defmulti my-method :hello :default ::default)
+
+  (defmethod my-method :world
+    [_]
+    (println "Hi"))
+
+  (deftype ImageSelection [data]
+    Transferable
+    (getTransferDataFlavors
+      [this]
+      (into-array DataFlavor [DataFlavor/imageFlavor]))
+
+    (isDataFlavorSupported
+      [this flavor]
+      (= DataFlavor/imageFlavor flavor))
+
+    (getTransferData
+      [this flavor]
+      (when (= DataFlavor/imageFlavor flavor)
+        (.getImage (ImageIcon. data)))))
+
+  (defprotocol P
+    (foo [this])
+    (bar-me [this] [this y])))


### PR DESCRIPTION
Resolve #20.

- Methods for `deftype`, `definterface`, `defrecord`, `reify` and `defprotocol` are highlighted with `font-lock-function-name-face`.

I've also changed some existing queries (I can revert it if those are undesirable):
- I think `clojure-ts--definition-symbol-regexp` is quite greedy. It highlights everything following a symbol prefixed with `def` with `font-lock-function-name-face`. As a result `deftype`, `defprotocol` etc were highlighted as functions, now types are highlighted with `font-lock-type-face` to be consistent with `clojure-mode`. 
- Namespace name is highlighted with `font-lock-type-face` to be consistent with `clojure-mode`.

Images:
- Before:
<img width="545" alt="image" src="https://github.com/clojure-emacs/clojure-ts-mode/assets/6093590/3a27ec0a-31d3-46d7-b16a-4c36b9349446">

- After:
<img width="515" alt="image" src="https://github.com/clojure-emacs/clojure-ts-mode/assets/6093590/58a57278-e896-4ea5-9c41-2e6911b8dfa8">

- `clojure-mode`
<img width="507" alt="image" src="https://github.com/clojure-emacs/clojure-ts-mode/assets/6093590/22ace28f-6e9a-4cd1-b082-aecb964571ee">

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! (there are no tests, but I've updated test clojure source).
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
