### PR TITLE
Add clojure-ts-toplevel-inside-comment-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+- Add custom option `clojure-ts-toplevel-inside-comment-form` as an equivalent to `clojure-toplevel-inside-comment-form` in clojure-mode (#30)
+
 ## 0.2.0
 
 - Pin grammar revision in treesit-language-source-alist

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Too highlight entire rich `comment` expression with the comment font face, set
 By default this is `nil`, so that anything within a `comment` expression is
 highlighted like regular clojure code.
 
+### Navigation and Evaluation
+
+To make forms inside of `(comment ...)` forms appear as toplevel forms for evaluation and navigation, set
+
+``` emacs-lisp
+(setq clojure-ts-toplevel-inside-comment-form t)
+```
+
 ## Rationale
 
 [clojure-mode](https://github.com/clojure-emacs/clojure-mode) has served us well

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -93,6 +93,12 @@ itself."
   :type 'boolean
   :package-version '(clojure-ts-mode . "0.2.0"))
 
+(defcustom clojure-ts-toplevel-inside-comment-form nil
+  "Eval top level forms inside comment forms instead of the comment form itself."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(clojure-ts-mode . "0.2.1"))
+
 (defvar clojure-ts--debug nil
   "Enables debugging messages, shows current node in mode-line.
 Only intended for use at development time.")
@@ -911,7 +917,10 @@ See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
   (setq-local treesit-defun-prefer-top-level t)
   (setq-local treesit-defun-tactic 'top-level)
   (setq-local treesit-defun-type-regexp
-              (rx (or "list_lit" "vec_lit" "map_lit")))
+              (cons (rx (or "list_lit" "vec_lit" "map_lit"))
+                    (lambda (node)
+                      (or (not clojure-ts-toplevel-inside-comment-form)
+                          (not (clojure-ts--definition-node-p "comment" node))))))
   (setq-local treesit-simple-indent-rules
               (clojure-ts--configured-indent-rules))
   (setq-local treesit-defun-name-function


### PR DESCRIPTION
Fixes #30

`clojure-ts-toplevel-inside-comment-form` is the equivalent to `clojure-toplevel-inside-comment-form` in clojure-mode. Defaults to `nil` so no change in behavior by default.

This change makes use of [`treesit-defun-type-regexp`s ability to use `(REGEXP . PRED)`](https://github.com/emacs-mirror/emacs/blob/a4587646fabf2b7f0cb19a7e0bee090f9106a73a/lisp/treesit.el#L2225-L2229) cons cells to reject `comment` as a defun if `clojure-ts-toplevel-inside-comment-form` is enabled.
