### PR TITLE
Consider all clojure sexps as defuns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main (unreleased)
 
 - Add custom option `clojure-ts-toplevel-inside-comment-form` as an equivalent to `clojure-toplevel-inside-comment-form` in clojure-mode (#30)
+- Change behavior of `beginning-of-defun` and `end-of-defun` to consider all Clojure sexps as defuns (#32)
 
 ## 0.2.0
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -917,7 +917,7 @@ See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
   (setq-local treesit-defun-prefer-top-level t)
   (setq-local treesit-defun-tactic 'top-level)
   (setq-local treesit-defun-type-regexp
-              (cons (rx (or "list_lit" "vec_lit" "map_lit"))
+              (cons (regexp-opt clojure-ts--sexp-nodes)
                     (lambda (node)
                       (or (not clojure-ts-toplevel-inside-comment-form)
                           (not (clojure-ts--definition-node-p "comment" node))))))

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -917,10 +917,13 @@ See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
   (setq-local treesit-defun-prefer-top-level t)
   (setq-local treesit-defun-tactic 'top-level)
   (setq-local treesit-defun-type-regexp
-              (cons (regexp-opt clojure-ts--sexp-nodes)
-                    (lambda (node)
-                      (or (not clojure-ts-toplevel-inside-comment-form)
-                          (not (clojure-ts--definition-node-p "comment" node))))))
+              (cons
+               ;; consider all clojure sexps as valid top level forms...
+               (regexp-opt clojure-ts--sexp-nodes)
+               ;; ...except `comment' forms if `clojure-ts-toplevel-inside-comment-form' is set
+               (lambda (node)
+                 (or (not clojure-ts-toplevel-inside-comment-form)
+                     (not (clojure-ts--definition-node-p "comment" node))))))
   (setq-local treesit-simple-indent-rules
               (clojure-ts--configured-indent-rules))
   (setq-local treesit-defun-name-function


### PR DESCRIPTION
Consider this clojure code, `|` indicating the point position


```clojure
(ns my.app)

(defn foo []
  (+ 1 1))

foo|

"another sexp"

(defn bar []
  (+ 2 1))
```

Without this change, `beginning-of-defun` would move point before the `(defn foo,,,)` as the symbol literal `foo` is not considered as a valid defun.

With this change, all clojure sexps will be considered as defuns, so `beginning-of-defun` moves point before `foo`, which I would consider as the expected behavior.

Similar for `cider-eval-defun-at-point`: At the point position indicated in the example without this change the `(defn bar,,,)` form is evaluated. With this change, `foo` is evaluated, which I also would consider the expected behavior.
