### PR TITLE
Fix flycheck errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## main (unreleased)
-
+- Rename all derived mode vars to match the package prefix. ([#36](https://github.com/clojure-emacs/clojure-ts-mode/pull/36))
+`clojurescript-ts-mode` -> `clojure-ts-clojurescript-mode`
+`clojurec-ts-mode` -> `clojure-ts-clojurec-mode`
+`clojure-dart-ts-mode` -> `clojure-ts-clojuredart-mode`
+`clojure-jank-ts-mode` -> `clojure-ts-jank-mode`
 - Add custom option `clojure-ts-toplevel-inside-comment-form` as an equivalent to `clojure-toplevel-inside-comment-form` in clojure-mode (#30)
 - Change behavior of `beginning-of-defun` and `end-of-defun` to consider all Clojure sexps as defuns (#32)
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -7,7 +7,7 @@
 ;; URL: http://github.com/clojure-emacs/clojure-ts-mode
 ;; Keywords: languages clojure clojurescript lisp
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "29"))
+;; Package-Requires: ((emacs "29.1"))
 
 ;; This file is not part of GNU Emacs.
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -861,22 +861,22 @@ forms like deftype, defrecord, reify, proxy, etc."
     ;(set-keymap-parent map clojure-mode-map)
     map))
 
-(defvar clojurescript-ts-mode-map
+(defvar clojure-ts-clojurescript-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map clojure-ts-mode-map)
     map))
 
-(defvar clojurec-ts-mode-map
+(defvar clojure-ts-clojurec-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map clojure-ts-mode-map)
     map))
 
-(defvar clojure-dart-ts-mode-map
+(defvar clojure-ts-clojuredart-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map clojure-ts-mode-map)
     map))
 
-(defvar clojure-jank-ts-mode-map
+(defvar clojure-ts-jank-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map clojure-ts-mode-map)
     map))
@@ -965,25 +965,25 @@ See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
         (setq-local transpose-sexps-function #'transpose-sexps-default-function)))))
 
 ;;;###autoload
-(define-derived-mode clojurescript-ts-mode clojure-ts-mode "ClojureScript[TS]"
+(define-derived-mode clojure-ts-clojurescript-mode clojure-ts-mode "ClojureScript[TS]"
   "Major mode for editing ClojureScript code.
 
 \\{clojurescript-ts-mode-map}")
 
 ;;;###autoload
-(define-derived-mode clojurec-ts-mode clojure-ts-mode "ClojureC[TS]"
+(define-derived-mode clojure-ts-clojurec-mode clojure-ts-mode "ClojureC[TS]"
   "Major mode for editing ClojureC code.
 
 \\{clojurec-ts-mode-map}")
 
 ;;;###autoload
-(define-derived-mode clojure-dart-ts-mode clojure-ts-mode "ClojureDart[TS]"
+(define-derived-mode clojure-ts-clojuredart-mode clojure-ts-mode "ClojureDart[TS]"
   "Major mode for editing Clojure Dart code.
 
 \\{clojure-dart-ts-mode-map}")
 
 ;;;###autoload
-(define-derived-mode clojure-jank-ts-mode clojure-ts-mode "Jank[TS]"
+(define-derived-mode clojure-ts-jank-mode clojure-ts-mode "Jank[TS]"
   "Major mode for editing Jank code.
 
 \\{clojure-jank-ts-mode-map}")


### PR DESCRIPTION
Fix all the errors from flycheck.
 
This contains a breaking change with the derived mode vars being renamed.

- `clojurescript-ts-mode` -> `clojure-ts-clojurescript-mode`
- `clojurec-ts-mode` -> `clojure-ts-clojurec-mode`
- `clojure-dart-ts-mode` -> `clojure-ts-clojuredart-mode`
- `clojure-jank-ts-mode` -> `clojure-ts-jank-mode`
