### PR TITLE
Fix missing `comment-add` variable in `clojure-ts-mode-variables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main (unreleased)
 
 - [#38]: Add support for `in-ns` forms in `clojure-ts-find-ns`.
+- [#46]: Fix missing `comment-add` variable in `clojure-ts-mode-variables` mentioned in [#26]
 
 ## 0.2.2 (2024-02-16)
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -912,6 +912,7 @@ forms like deftype, defrecord, reify, proxy, etc."
 (defun clojure-ts-mode-variables (&optional markdown-available)
   "Initialize buffer-local variables for `clojure-ts-mode'.
 See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
+  (setq-local comment-add 1)
   (setq-local comment-start ";")
   (setq-local treesit-font-lock-settings
               (clojure-ts--font-lock-settings markdown-available))


### PR DESCRIPTION
This resolves #26

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
