### PR TITLE
Update README.md to show CIDER and inf-clojure status

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,7 @@ After installing the package do the following.
 
 ### Does `clojure-ts-mode` work with CIDER?
 
-~~Not yet out of the box, but that [should change soon](https://github.com/clojure-emacs/cider/pull/3461). Feel free to help out with the remaining work, so we can expedite the process.~~
-
-Support for `clojure-ts-mode` has landed on the `master` branch of CIDER (and will be part of CIDER 1.14 when it's released). Make sure to grab the latest CIDER from MELPA/GitHub.
+Yes! Preliminary support for `clojure-ts-mode` was released in [CIDER 1.14](https://github.com/clojure-emacs/cider/releases/tag/v1.14.0). Make sure to grab the latest CIDER from MELPA/GitHub. Note that `clojure-mode` is still needed for some APIs that haven't yet been ported to `clojure-ts-mode`.
 
 For now, when you take care of the keybindings for the CIDER commands you use and ensure `cider-mode` is enabled for `clojure-ts-mode` buffers in your config, most functionality should already work:
 
@@ -228,7 +226,7 @@ Check out [this article](https://metaredux.com/posts/2024/02/19/cider-preliminar
 
 ### Does `clojure-ts-mode` work with `inf-clojure`?
 
-[Ditto.](https://github.com/clojure-emacs/inf-clojure/pull/215)
+Currently, there is an [open PR](https://github.com/clojure-emacs/inf-clojure/pull/215) adding support for inf-clojure.
 
 ## License
 


### PR DESCRIPTION
I noticed that the readme was out of date for CIDER.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
