### PR TITLE
Fix semantic indentation of quoted functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#42]: Fix imenu support for definitions with metadata.
 - [#42]: Fix font locking of definitions with metadata
 - [#42]: Fix indentation of definitions with metadata
+- Fix semantic indentation of quoted functions
 
 ## 0.2.2 (2024-02-16)
 

--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -135,4 +135,9 @@ DESCRIPTION is a string with the description of the spec."
 (defn c
   \"hello\"
   [_foo]
-  (+ 1 1))"))
+  (+ 1 1))")
+
+(when-indenting-it "should support function calls via vars"
+   "
+(#'foo 5
+       6)"))

--- a/test/samples/indentation.clj
+++ b/test/samples/indentation.clj
@@ -60,6 +60,8 @@
 (clojure.core/filter even?
                      (range 1 10))
 
+(#'filter even?
+          (range 10))
 
 (filter
  even?


### PR DESCRIPTION
Fixes an error where quoted functions would not align correctly with semantic indentation. Adds an example to the test sample.


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
