### PR TITLE
Let clojure-ts-mode derive from clojure-mode for Emacs 30+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#38]: Add support for `in-ns` forms in `clojure-ts-find-ns`.
 - [#46]: Fix missing `comment-add` variable in `clojure-ts-mode-variables` mentioned in [#26]
 - Add imenu support for `deftest` definitions.
+- [#53]: Let `clojure-ts-mode` derive from `clojure-mode` for Emacs 30+.
 
 ## 0.2.2 (2024-02-16)
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -966,6 +966,11 @@ See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
       (when (fboundp 'transpose-sexps-default-function)
         (setq-local transpose-sexps-function #'transpose-sexps-default-function)))))
 
+;; For Emacs 30+, so that `clojure-ts-mode' is treated as deriving from
+;; `clojure-mode'
+(when (fboundp #'derived-mode-add-parents)
+  (derived-mode-add-parents 'clojure-ts-mode '(clojure-mode)))
+
 ;;;###autoload
 (define-derived-mode clojure-ts-clojurescript-mode clojure-ts-mode "ClojureScript[TS]"
   "Major mode for editing ClojureScript code.


### PR DESCRIPTION
Emacs 30 defines the function `derived-mode-add-parents` that is used for the built-in *-ts-mode, this will make `(provided-mode-derived-p 'clojure-ts-mode 'clojure-mode)` return true just like other treesit major modes.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
