### PR TITLE
Add custom `fill-paragraph` function to respect docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - [#42]: Fix font locking of definitions with metadata
 - [#42]: Fix indentation of definitions with metadata
 - Fix semantic indentation of quoted functions
+- Add custom `fill-paragraph-function` which respects docstrings similar to
+  `clojure-mode`.
 
 ## 0.2.2 (2024-02-16)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ To make forms inside of `(comment ...)` forms appear as top-level forms for eval
 (setq clojure-ts-toplevel-inside-comment-form t)
 ```
 
+### Fill paragraph
+
+To change the maximal line length used by `M-x prog-fill-reindent-defun` (also
+bound to `M-q` by default) to reformat docstrings and comments it's possible to
+customize `clojure-ts-fill-paragraph` variable (by default set to the value of
+Emacs' `fill-paragraph` value).
+
+Every new line in the docstrings is indented by
+`clojure-ts-docstring-fill-prefix-width` number of spaces (set to 2 by default
+which matches the `clojure-mode` settings).
+
 ## Rationale
 
 [clojure-mode](https://github.com/clojure-emacs/clojure-mode) has served us well

--- a/test/clojure-ts-mode-fill-paragraph-test.el
+++ b/test/clojure-ts-mode-fill-paragraph-test.el
@@ -1,0 +1,62 @@
+;;; clojure-ts-mode-fill-paragraph-test.el ---       -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Roman Rudakov
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; The unit test suite of CLojure TS Mode
+
+;;; Code:
+
+(require 'clojure-ts-mode)
+(require 'buttercup)
+
+(describe "clojure-ts--fill-paragraph"
+  (it "should reformat only the docstring"
+    (with-clojure-ts-buffer "(ns foo)
+
+(defn hello-world
+  \"This is a very long docstring that should be reformatted using fill-paragraph function.\"
+  []
+  (pringln \"Hello world\"))"
+                            (goto-char 40)
+                            (prog-fill-reindent-defun)
+                            (expect (buffer-substring-no-properties (point-min) (point-max))
+                                    :to-equal
+                                    "(ns foo)
+
+(defn hello-world
+  \"This is a very long docstring that should be reformatted using
+  fill-paragraph function.\"
+  []
+  (pringln \"Hello world\"))")))
+
+  (it "should reformat normal comments properly"
+    (with-clojure-ts-buffer "(ns foo)
+
+;; This is a very long comment that should be reformatted using fill-paragraph function."
+                              (goto-char 20)
+                              (prog-fill-reindent-defun)
+                              (expect (buffer-substring-no-properties (point-min) (point-max))
+                                      :to-equal
+                                      "(ns foo)
+
+;; This is a very long comment that should be reformatted using
+;; fill-paragraph function."))))
+
+;;; clojure-ts-mode-fill-paragraph-test.el ends here


### PR DESCRIPTION
Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
