### PR TITLE
Add customization option to disable markdown syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Fix semantic indentation of quoted functions
 - Add custom `fill-paragraph-function` which respects docstrings similar to
   `clojure-mode`.
+- Add customization option to disable markdown syntax highlighting in the
+  docstrings.
 
 ## 0.2.2 (2024-02-16)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ To highlight entire rich `comment` expression with the comment font face, set
 By default this is `nil`, so that anything within a `comment` expression is
 highlighted like regular clojure code.
 
+### Highlight markdown syntax in docstrings
+
+By default markdown syntax is highlighted in the docstrings using
+`markdown_inline` grammar. To disable this feature set
+
+``` emacs-lisp
+(setopt clojure-ts-use-markdown-inline nil)
+```
+
 ### Navigation and Evaluation
 
 To make forms inside of `(comment ...)` forms appear as top-level forms for evaluation and navigation, set

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -112,6 +112,12 @@ double quotes on the third column."
   :safe #'integerp
   :package-version '(clojure-ts-mode . "0.2.3"))
 
+(defcustom clojure-ts-use-markdown-inline t
+  "When non-nil, use Markdown inline grammar for docstrings."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(clojure-ts-mode . "0.2.3"))
+
 (defvar clojure-ts--debug nil
   "Enables debugging messages, shows current node in mode-line.
 Only intended for use at development time.")
@@ -1010,13 +1016,14 @@ See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
 \\{clojure-ts-mode-map}"
   :syntax-table clojure-ts-mode-syntax-table
   (clojure-ts--ensure-grammars)
-  (let ((markdown-available (treesit-ready-p 'markdown_inline t)))
-    (when markdown-available
+  (let ((use-markdown-inline (and clojure-ts-use-markdown-inline
+                                  (treesit-ready-p 'markdown_inline t))))
+    (when use-markdown-inline
       (treesit-parser-create 'markdown_inline)
       (setq-local treesit-range-settings clojure-ts--treesit-range-settings))
     (when (treesit-ready-p 'clojure)
       (treesit-parser-create 'clojure)
-      (clojure-ts-mode-variables markdown-available)
+      (clojure-ts-mode-variables use-markdown-inline)
       (when clojure-ts--debug
         (setq-local treesit--indent-verbose t)
         (when (eq clojure-ts--debug 'font-lock)


### PR DESCRIPTION
Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

---

I would like to introduce a new customization option to disable inline markdown. 

After working for some time with `clojure-ts-mode` on relatively big project I noticed some problems with it. Markdown syntax highlighting is not accurate (note closing backtick has different color in different docstrings):

<img width="406" alt="image" src="https://github.com/user-attachments/assets/ce67dbc4-8441-4ec7-8faa-c562d75c3092" />

Also having it enabled sometimes introduces memory leaks. Emacs hangs and consumes all available RAM. Unfortunately I couldn't figure out a reliable recipe to reproduce the memory leak.

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
