### PR TITLE
Define list thing to improve navigation in Emacs 31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+- [[#62](https://github.com/clojure-emacs/clojure-ts-mode/issues/62)]: Define `list` "thing" to improve navigation in Emacs 31.
+
 ## 0.2.3 (2025-03-04)
 
 - [#38]: Add support for `in-ns` forms in `clojure-ts-find-ns`.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ Here are some notable examples:
 
 - On Emacs 29 the parent mode is `prog-mode`, but on Emacs 30+ it's both `prog-mode`
 and `clojure-mode` (this is very helpful when dealing with `derived-mode-p` checks)
+- Navigation by sexp/lists might work differently on Emacs versions lower
+  than 31. Starting with version 31, Emacs uses TreeSitter 'things' settings, if
+  available, to rebind some commands.
 
 ## Frequently Asked Questions
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -918,10 +918,16 @@ If JUSTIFY is non-nil, justify as well as fill the paragraph."
     "unquote_splicing_lit" "unquoting_lit")
   "A regular expression that matches nodes that can be treated as s-expressions.")
 
+(defconst clojure-ts--list-nodes
+  '("list_lit" "anon_fn_lit" "read_cond_lit" "splicing_read_cond_lit"
+    "map_lit" "ns_map_lit" "vec_lit" "set_lit")
+  "A regular expression that matches nodes that can be treated as lists.")
+
 (defconst clojure-ts--thing-settings
   `((clojure
-     (sexp ,(regexp-opt clojure-ts--sexp-nodes)
-           text ,(regexp-opt '("comment"))))))
+     (sexp ,(regexp-opt clojure-ts--sexp-nodes))
+     (list ,(regexp-opt clojure-ts--list-nodes))
+     (text ,(regexp-opt '("comment"))))))
 
 (defvar clojure-ts-mode-map
   (let ((map (make-sparse-keymap)))
@@ -1043,7 +1049,8 @@ See `clojure-ts--font-lock-settings' for usage of MARKDOWN-AVAILABLE."
       ;; Workaround for treesit-transpose-sexps not correctly working with
       ;; treesit-thing-settings on Emacs 30.
       ;; Once treesit-transpose-sexps it working again this can be removed
-      (when (fboundp 'transpose-sexps-default-function)
+      (when (and (fboundp 'transpose-sexps-default-function)
+                 (< emacs-major-version 31))
         (setq-local transpose-sexps-function #'transpose-sexps-default-function)))))
 
 ;; For Emacs 30+, so that `clojure-ts-mode' is treated as deriving from


### PR DESCRIPTION
If list thing is defined, Emacs 31 will set a few options automatically to improve navigation by lists/sexp etc.

Big thanks for the patch to Juri Linkov <juri@linkov.net>.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
