### PR TITLE
Improve semantic indentation rules to be more consistent with cljfmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Highlight named lambda functions properly.
   - Fix syntax highlighting for functions and vars with metadata on the previous
     line.
+- Improve semantic indentation rules to be more consistent with cljfmt.
+- Introduce `clojure-ts-semantic-indent-rules` customization option.
 
 ## 0.2.3 (2025-03-04)
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,45 @@ Set the var `clojure-ts-indent-style` to change it.
 >
 > You can find [this article](https://metaredux.com/posts/2020/12/06/semantic-clojure-formatting.html) comparing semantic and fixed indentation useful.
 
+#### Customizing semantic indentation
+
+The indentation of special forms and macros with bodies is controlled via
+`clojure-ts-semantic-indent-rules`. Nearly all special forms and built-in macros
+with bodies have special indentation settings in clojure-ts-mode, which are
+aligned with cljfmt indent rules. You can add/alter the indentation settings in
+your personal config. Let's assume you want to indent `->>` and `->` like this:
+
+```clojure
+(->> something
+  ala
+  bala
+  portokala)
+```
+
+You can do so by putting the following in your config:
+
+```emacs-lisp
+(setopt clojure-ts-semantic-indent-rules '(("->" . (:block 1))
+                                           ("->>" . (:block 1))))
+```
+
+This means that the body of the `->`/`->>` is after the first argument.
+
+The default set of rules is defined as
+`clojure-ts--semantic-indent-rules-defaults`, any rule can be overridden using
+customization option.
+
+There are 2 types of rules supported: `:block` and `:inner`, similarly to
+cljfmt. If rule is defined as `:block n`, `n` means a number of arguments after
+which begins the body. If rule is defined as `:inner n`, each form in the body
+is indented with 2 spaces regardless of `n` value (currently all default rules
+has 0 value).
+
+For example:
+- `do` has a rule `:block 0`.
+- `when` has a rule `:block 1`.
+- `defn` and `fn` have a rule `:inner 0`.
+
 ### Font Locking
 
 To highlight entire rich `comment` expression with the comment font face, set

--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -140,4 +140,103 @@ DESCRIPTION is a string with the description of the spec."
 (when-indenting-it "should support function calls via vars"
    "
 (#'foo 5
-       6)"))
+       6)")
+
+(when-indenting-it "should support block-0 expressions"
+  "
+(do (aligned)
+    (vertically))"
+
+  "
+(do
+  (indented)
+  (with-2-spaces))"
+
+  "
+(future
+  (body is indented))"
+
+  "
+(try
+  (something)
+  ;; A bit of block 2 rule
+  (catch Exception e
+    \"Third argument is indented with 2 spaces.\")
+  (catch ExceptionInfo
+         e-info
+    \"Second argument is aligned vertically with the first one.\"))")
+
+(when-indenting-it "should support block-1 expressions"
+  "
+(case x
+  2 (print 2)
+  3 (print 3)
+  (print \"Default\"))"
+
+  "
+(cond-> {}
+  :always (assoc :hello \"World\")
+  false (do nothing))"
+
+  "
+(with-precision 32
+  (/ (bigdec 20) (bigdec 30)))"
+
+  "
+(testing \"Something should work\"
+  (is (something-working?)))")
+
+(when-indenting-it "should support block-2 expressions"
+  "
+(are [x y]
+     (= x y)
+  2 3
+  4 5
+  6 6)"
+
+  "
+(as-> {} $
+  (assoc $ :hello \"World\"))"
+
+  "
+(as-> {}
+      my-map
+  (assoc my-map :hello \"World\"))"
+
+  "
+(defrecord MyThingR []
+  IProto
+  (foo [this x] x))")
+
+(when-indenting-it "should support inner-0 expressions"
+  "
+(fn named-lambda [x]
+  (+ x x))"
+
+  "
+(defmethod hello :world
+  [arg1 arg2]
+  (+ arg1 arg2))"
+
+  "
+(reify
+  AutoCloseable
+  (close
+    [this]
+    (is properly indented)))")
+
+(it "should prioritize custom semantic indentation rules"
+  (with-clojure-ts-buffer "
+(are [x y]
+     (= x y)
+  2 3
+  4 5
+  6 6)"
+    (setopt clojure-ts-semantic-indent-rules '(("are" . (:block 1))))
+    (indent-region (point-min) (point-max))
+    (expect (buffer-string) :to-equal "
+(are [x y]
+  (= x y)
+  2 3
+  4 5
+  6 6)"))))

--- a/test/samples/indentation.clj
+++ b/test/samples/indentation.clj
@@ -79,8 +79,6 @@
   :another-keyword 2}
  "default value")
 
-
-
 (defprotocol IProto
   (foo [this x]
     "`this` is a docstring.")
@@ -121,7 +119,6 @@
           ([a b]
            b))})
 
-
 ^:foo
 (def a 1)
 
@@ -145,3 +142,71 @@
   "hello"
   [_foo]
   (+ 1 1))
+
+;;; Block 0 rule
+
+(do (aligned)
+    (vertically))
+
+(do
+  (indented)
+  (with-2-spaces))
+
+(future
+  (body is indented))
+
+(try
+  (something)
+  ;; A bit of block 2 rule
+  (catch Exception e
+    "Third argument is indented with 2 spaces.")
+  (catch ExceptionInfo
+         e-info
+    "Second argument is aligned vertically with the first one."))
+
+;;; Block 1 rule
+
+(case x
+  2 (print 2)
+  3 (print 3)
+  (print "Default"))
+
+(cond-> {}
+  :always (assoc :hello "World")
+  false (do nothing))
+
+(with-precision 32
+  (/ (bigdec 20) (bigdec 30)))
+
+(testing "Something should work"
+  (is (something-working?)))
+
+;;; Block 2 rule
+
+(are [x y]
+     (= x y)
+  2 3
+  4 5
+  6 6)
+
+(as-> {} $
+  (assoc $ :hello "World"))
+
+(as-> {}
+      my-map
+  (assoc my-map :hello "World"))
+
+;;; Inner 0 rule
+
+(fn named-lambda [x]
+  (+ x x))
+
+(defmethod hello :world
+  [arg1 arg2]
+  (+ arg1 arg2))
+
+(reify
+  AutoCloseable
+  (close
+    [this]
+    (is properly indented)))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -24,7 +24,8 @@
 ;;; Code:
 
 (defmacro with-clojure-ts-buffer (text &rest body)
-  "Create a temporary buffer, insert TEXT,switch to clojure-ts-mode.
+  "Create a temporary buffer, insert TEXT, switch to `clojure-ts-mode'.
+
 And evaluate BODY."
   (declare (indent 1))
   `(with-temp-buffer


### PR DESCRIPTION
Example:

<img width="561" alt="image" src="https://github.com/user-attachments/assets/27665e0f-7dcc-41a5-9521-92e3001cafdc" />

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
