### PR TITLE
Fix some issues with indentation for items with metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     line.
 - Improve semantic indentation rules to be more consistent with cljfmt.
 - Introduce `clojure-ts-semantic-indent-rules` customization option.
+- [#61](https://github.com/clojure-emacs/clojure-ts-mode/issues/61): Fix issue with indentation of collection items with metadata.
+- Proper syntax highlighting for expressions with metadata.
 
 ## 0.2.3 (2025-03-04)
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,11 @@ and `clojure-mode` (this is very helpful when dealing with `derived-mode-p` chec
 - Navigation by sexp/lists might work differently on Emacs versions lower
   than 31. Starting with version 31, Emacs uses TreeSitter 'things' settings, if
   available, to rebind some commands.
+- The indentation of list elements with metadata is inconsistent with other
+  collections. This inconsistency stems from the grammar's interpretation of
+  nearly every definition or function call as a list. Therefore, modifying the
+  indentation for list elements would adversely affect the indentation of
+  numerous other forms.
 
 ## Frequently Asked Questions
 

--- a/test/clojure-ts-mode-font-lock-test.el
+++ b/test/clojure-ts-mode-font-lock-test.el
@@ -162,4 +162,9 @@ DESCRIPTION is the description of the spec."
   (when-fontifying-it "non-built-ins-with-same-name"
     ("(h/for query {})"
      (2 2 font-lock-type-face)
-     (4 6 nil))))
+     (4 6 nil)))
+
+  (when-fontifying-it "special-forms-with-metadata"
+    ("^long (if true 1 2)"
+     (2 5 font-lock-type-face)
+     (8 9 font-lock-keyword-face))))

--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -239,4 +239,29 @@ DESCRIPTION is a string with the description of the spec."
   (= x y)
   2 3
   4 5
-  6 6)"))))
+  6 6)")))
+
+(it "should indent collections elements with metadata correctly"
+  "
+(def x
+  [a b [c ^:foo
+        d
+        e]])"
+
+  "
+#{x
+  y ^:foo
+  z}"
+
+  "
+{:hello ^:foo
+ \"world\"
+ :foo
+ \"bar\"}")
+
+(it "should indent body of special forms correctly considering metadata"
+  "
+(let [result ^long
+      (if true
+        1
+        2)])"))

--- a/test/samples/indentation.clj
+++ b/test/samples/indentation.clj
@@ -210,3 +210,59 @@
   (close
     [this]
     (is properly indented)))
+
+(def x
+  [a b [c ^:foo
+        d
+        e]])
+
+#{x
+  y ^:foo
+  z}
+
+{:hello ^:foo
+ "world"
+ :foo
+ "bar"}
+
+;; NOTE: List elements with metadata are not indented correctly.
+'(one
+  two ^:foo
+      three)
+
+^{:nextjournal.clerk/visibility {:code :hide}}
+(defn actual
+  [args])
+
+(def ^:private hello
+  "World")
+
+;; A few examples from clojure core.
+
+;; NOTE: This one is not indented correctly, I'm keeping it here as a reminder
+;; to fix it later.
+(defonce ^:dynamic
+         ^{:private true
+           :doc "A ref to a sorted set of symbols representing loaded libs"}
+         *loaded-libs* (ref (sorted-set)))
+
+(defn index-of
+  "Return index of value (string or char) in s, optionally searching
+  forward from from-index. Return nil if value not found."
+  {:added "1.8"}
+  ([^CharSequence s value]
+   (let [result ^long
+         (if (instance? Character value)
+           (.indexOf (.toString s) ^int (.charValue ^Character value))
+           (.indexOf (.toString s) ^String value))]
+     (if (= result -1)
+       nil
+       result)))
+  ([^CharSequence s value ^long from-index]
+   (let [result ^long
+         (if (instance? Character value)
+           (.indexOf (.toString s) ^int (.charValue ^Character value) (unchecked-int from-index))
+           (.indexOf (.toString s) ^String value (unchecked-int from-index)))]
+     (if (= result -1)
+       nil
+       result))))


### PR DESCRIPTION
- Collection elements (except of lists) are properly indented.
- Body of special forms when the entire form has metadata is properly indented.
- Additionally fix syntax highlighting of special forms when the entire form has metadata.

Close #61 

Before:
<img width="134" alt="image" src="https://github.com/user-attachments/assets/48c8e186-c1c3-4b6d-9275-8a30f76179d7" />

Here besides incorrect indentation, `if` is not highlighted properly:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/5e524083-503f-4fdb-b998-1d1939da172d" />

After:
<img width="203" alt="image" src="https://github.com/user-attachments/assets/46879504-a4ed-42c7-89d1-35ce8872a1ef" />

<img width="727" alt="image" src="https://github.com/user-attachments/assets/6fadd4e8-023d-4930-a087-15f9ab724211" />

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
