### PR TITLE
Basic support for dynamic indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Introduce `clojure-ts-semantic-indent-rules` customization option.
 - [#61](https://github.com/clojure-emacs/clojure-ts-mode/issues/61): Fix issue with indentation of collection items with metadata.
 - Proper syntax highlighting for expressions with metadata.
+- Add basic support for dynamic indentation via `clojure-ts-get-indent-function`.
 
 ## 0.2.3 (2025-03-04)
 


### PR DESCRIPTION
This PR introduces `clojure-ts-get-indent-function` variable, which can be set by CIDER as:

```emacs-lisp
(setq-local clojure-ts-get-indent-function #'cider--get-symbol-indent)
```

to enable dynamic indentation based on `:style/indent` metadata. Currently it supports only first level, so `{:style/indent 1}` and `{:style/indent [1 [[:defn]] :form]}` are both translated to `(:block 1)` rule.

I haven't added anything to README, because it's internal change, similar function is not mentioned in `clojure-mode` readme as well.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
