### PR TITLE
Pass fully qualified symbol to clojure-ts-get-indent-function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#69](https://github.com/clojure-emacs/clojure-ts-mode/pull/69): Add basic support for dynamic indentation via `clojure-ts-get-indent-function`.
 - [#70](https://github.com/clojure-emacs/clojure-ts-mode/pull/70): Add support for nested indentation rules.
 - [#71](https://github.com/clojure-emacs/clojure-ts-mode/pull/71): Properly highlight function name in `letfn` form.
+- [#72](https://github.com/clojure-emacs/clojure-ts-mode/pull/72): Pass fully qualified symbol to `clojure-ts-get-indent-function`.
 
 ## 0.2.3 (2025-03-04)
 

--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -96,7 +96,7 @@ DESCRIPTION is a string with the description of the spec."
   (when (stringp symbol-name)
     (cond
      ((string-equal symbol-name "my-with-in-str") 1)
-     ((string-equal symbol-name "my-letfn") '(1 ((:defn)) :form)))))
+     ((string-equal symbol-name "my.alias/my-letfn") '(1 ((:defn)) :form)))))
 
 
 (describe "indentation"
@@ -305,10 +305,10 @@ DESCRIPTION is a string with the description of the spec."
   [fnspecs & body]
   ~@body)
 
-(my-letfn [(twice [x]
-          (* x 2))
-          (six-times [y]
-          (* (twice y) 3))]
+(my.alias/my-letfn [(twice [x]
+                    (* x 2))
+                   (six-times [y]
+                  (* (twice y) 3))]
 (println \"Twice 15 =\" (twice 15))
 (println \"Six times 15 =\" (six-times 15)))"
     (setq-local clojure-ts-get-indent-function #'cider--get-symbol-indent-mock)
@@ -320,9 +320,9 @@ DESCRIPTION is a string with the description of the spec."
   [fnspecs & body]
   ~@body)
 
-(my-letfn [(twice [x]
-             (* x 2))
-           (six-times [y]
-             (* (twice y) 3))]
+(my.alias/my-letfn [(twice [x]
+                      (* x 2))
+                    (six-times [y]
+                      (* (twice y) 3))]
   (println \"Twice 15 =\" (twice 15))
   (println \"Six times 15 =\" (six-times 15)))"))))


### PR DESCRIPTION
When I started testing it with CIDER I realized that we have to pass fully qualified symbol name to `cider--get-symbol-indent`, otherwise it won't resolve it and won't return indentation metadata.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
