### PR TITLE
Add imenu support for keyword definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - [#70](https://github.com/clojure-emacs/clojure-ts-mode/pull/70): Add support for nested indentation rules.
 - [#71](https://github.com/clojure-emacs/clojure-ts-mode/pull/71): Properly highlight function name in `letfn` form.
 - [#72](https://github.com/clojure-emacs/clojure-ts-mode/pull/72): Pass fully qualified symbol to `clojure-ts-get-indent-function`.
-- Improve performance of semantic indentation by caching rules.
+- [#76](https://github.com/clojure-emacs/clojure-ts-mode/pull/76): Improve performance of semantic indentation by caching rules.
+- [#74](https://github.com/clojure-emacs/clojure-ts-mode/issues/74): Add imenu support for keywords definitions.
 
 ## 0.2.3 (2025-03-04)
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,19 @@ Every new line in the docstrings is indented by
 `clojure-ts-docstring-fill-prefix-width` number of spaces (set to 2 by default
 which matches the `clojure-mode` settings).
 
+#### imenu
+
+`clojure-ts-mode` supports various types of definition that can be navigated
+using `imenu`, such as:
+
+- namespace
+- function
+- macro
+- var
+- interface (forms such as `defprotocol`, `definterface` and `defmulti`)
+- class (forms such as `deftype`, `defrecord` and `defstruct`)
+- keyword (for example, spec definitions)
+
 ## Migrating to clojure-ts-mode
 
 If you are migrating to `clojure-ts-mode` note that `clojure-mode` is still required for cider and clj-refactor packages to work properly.

--- a/test/clojure-ts-mode-imenu-test.el
+++ b/test/clojure-ts-mode-imenu-test.el
@@ -29,10 +29,18 @@
 (describe "clojure-ts-mode imenu integration"
   (it "should index def with meta data"
     (with-clojure-ts-buffer "^{:foo 1}(def a 1)"
-      (expect (imenu--in-alist "a" (imenu--make-index-alist))
-              :not :to-be nil)))
+      (let ((flatten-index (imenu--flatten-index-alist (imenu--make-index-alist) t)))
+        (expect (imenu-find-default "a" flatten-index)
+                :to-equal "Variable:a"))))
 
   (it "should index defn with meta data"
     (with-clojure-ts-buffer "^{:foo 1}(defn a [])"
-      (expect (imenu--in-alist "a" (imenu--make-index-alist))
-              :not :to-be nil))))
+      (let ((flatten-index (imenu--flatten-index-alist (imenu--make-index-alist) t)))
+        (expect (imenu-find-default "a" flatten-index)
+                :to-equal "Function:a"))))
+
+  (it "should index def with keywords as a first item"
+    (with-clojure-ts-buffer "(s/def ::username string?)"
+      (let ((flatten-index (imenu--flatten-index-alist (imenu--make-index-alist) t)))
+        (expect (imenu-find-default "username" flatten-index)
+                :to-equal "Keyword:username")))))

--- a/test/samples/spec.clj
+++ b/test/samples/spec.clj
@@ -1,0 +1,7 @@
+(ns spec
+  (:require
+   [clojure.spec.alpha :as s]))
+
+(s/def ::username string?)
+(s/def ::age number?)
+(s/def ::email string?)


### PR DESCRIPTION
Close #74 

I decided to make it more generic and add support for all def forms with keywords. It might be useful for other libraries (like [spec-tools](https://github.com/metosin/spec-tools) for eample).

Before:

<img width="625" alt="image" src="https://github.com/user-attachments/assets/c9d76508-e112-4ad8-a9d3-fb69fe4e6376" />

After:

<img width="657" alt="image" src="https://github.com/user-attachments/assets/08baed64-eac6-4724-ab3e-e61185f3a602" />

I use `imenu-flatten 'prefix` option to display all items on the screenshots.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
