### PR TITLE
Improve performance of semantic indentation by caching rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#70](https://github.com/clojure-emacs/clojure-ts-mode/pull/70): Add support for nested indentation rules.
 - [#71](https://github.com/clojure-emacs/clojure-ts-mode/pull/71): Properly highlight function name in `letfn` form.
 - [#72](https://github.com/clojure-emacs/clojure-ts-mode/pull/72): Pass fully qualified symbol to `clojure-ts-get-indent-function`.
+- Improve performance of semantic indentation by caching rules.
 
 ## 0.2.3 (2025-03-04)
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,24 @@ For example:
 - `defn` and `fn` have a rule `((:inner 0))`.
 - `letfn` has a rule `((:block 1) (:inner 2 0))`.
 
+Note that `clojure-ts-semantic-indent-rules` should be set using the
+customization interface or `setopt`; otherwise, it will not be applied
+correctly.
+
+#### Project local indentation
+
+Custom indentation rules can be set for individual projects. To achieve this,
+you need to create a `.dir-locals.el` file in the project root. The content
+should look like:
+
+```emacs-lisp
+((clojure-ts-mode . ((clojure-ts-semantic-indent-rules . (("with-transaction" . ((:block 1)))
+                                                          ("with-retry" . ((:block 1))))))))
+```
+
+In order to apply directory-local variables to existing buffers, they must be
+reverted.
+
 ### Font Locking
 
 To highlight entire rich `comment` expression with the comment font face, set


### PR DESCRIPTION
I've noticed that reindenting big file is pretty slow, profiler report indicated that the bottleneck is the calculation of combined indentation rules from default settings and user customizations:

```emacs-lisp
(seq-union (or rules clojure-ts-semantic-indent-rules)
             clojure-ts--semantic-indent-rules-defaults
             (lambda (e1 e2) (equal (car e1) (car e2))))
```

this is called every time we need to calculate indentation for a single line. 

This PR introduces buffer local variable `clojure-ts--semantic-indent-rules-cache` which stores pre-calculated rules. This variable is set when `clojure-ts-mode` is activated and updated every time when `clojure-ts-semantic-indent-rules` is updated or file local variables are updated (in case when indentation rules are defined in `.dir-locals.el` for example.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
