### PR TITLE
Update grammars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#72](https://github.com/clojure-emacs/clojure-ts-mode/pull/72): Pass fully qualified symbol to `clojure-ts-get-indent-function`.
 - [#76](https://github.com/clojure-emacs/clojure-ts-mode/pull/76): Improve performance of semantic indentation by caching rules.
 - [#74](https://github.com/clojure-emacs/clojure-ts-mode/issues/74): Add imenu support for keywords definitions.
+- [#77](https://github.com/clojure-emacs/clojure-ts-mode/issues/77): Update grammars to the latest versions.
 
 ## 0.2.3 (2025-03-04)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Once installed, evaluate clojure-ts-mode.el and you should be ready to go.
 `clojure-ts-mode` makes use of two TreeSitter grammars to work properly:
 
 - The Clojure grammar, mentioned earlier
-- [markdown_inline](https://github.com/MDeiml/tree-sitter-markdown), which
+- [markdown-inline](https://github.com/MDeiml/tree-sitter-markdown), which
 will be used for docstrings if available and if `clojure-ts-use-markdown-inline` is enabled.
 
 If you have `git` and a C compiler (`cc`) available on your system's `PATH`,
@@ -136,6 +136,17 @@ If `clojure-ts-mode` fails to automatically install the grammar, you have the
 option to install it manually, Please, refer to the installation instructions of
 each required grammar and make sure you're install the versions expected. (see
 `clojure-ts-grammar-recipes` for details)
+
+### Upgrading tree-sitter grammars
+
+To reinstall or upgrade TreeSitter grammars, you can execute:
+
+```emacs-lisp
+M-x clojure-ts-reinstall-grammars
+```
+
+This will install the latest compatible grammars, even if they are already
+installed.
 
 ## Configuration
 


### PR DESCRIPTION
Close #77 

Some highlights:
- I renamed `markdown_inline` to `markdown-inline`. `markdown-ts-mode` was added to Emacs master and it expects `markdown-inline` grammar (https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/textmodes/markdown-ts-mode.el#n62), so I decided to make `clojure-ts-mode` aligned with Emacs master (otherwise there would be 2 markdown inline binaries)
- I added `clojure-ts-reinstall-grammars` function
- I have been using it with enabled `markdown-inline` feature and I couldn't reproduce memory leak. Hopefully it's fixed by updating the grammar. But I'm still observing the problem with incorrect fontification when backticks in the docstrings are unbalanced, as mentioned in #60. I'm thinking about submitting a bug report to Emacs and get some help regarding this situation.
- I've updated query for highlighting variables in docstrings with `markdown-inline` grammar, now when backticks are balanced, they are always highlighted correctly.


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
