### PR TITLE
Improve markdown highlighting in the docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#76](https://github.com/clojure-emacs/clojure-ts-mode/pull/76): Improve performance of semantic indentation by caching rules.
 - [#74](https://github.com/clojure-emacs/clojure-ts-mode/issues/74): Add imenu support for keywords definitions.
 - [#77](https://github.com/clojure-emacs/clojure-ts-mode/issues/77): Update grammars to the latest versions.
+- [#79](https://github.com/clojure-emacs/clojure-ts-mode/pull/79): Improve markdown highlighting in the docstrings.
 
 ## 0.2.3 (2025-03-04)
 

--- a/Eldev
+++ b/Eldev
@@ -17,7 +17,7 @@
 (setq checkdoc-permit-comma-termination-flag t)
 (setq checkdoc--interactive-docstring-flag nil)
 
-(setf eldev-lint-default '(elisp))
+(setq eldev-lint-default-excluded '(package))
 
 (with-eval-after-load 'elisp-lint
   ;; We will byte-compile with Eldev.

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -514,7 +514,14 @@ with the markdown-inline grammar."
       :feature 'doc
       :language 'markdown-inline
       :override t
-      `((code_span) @font-lock-constant-face)))
+      `([((image_description) @link)
+         ((link_destination) @font-lock-constant-face)
+         ((code_span) @font-lock-constant-face)
+         ((emphasis) @underline)
+         ((strong_emphasis) @bold)
+         (inline_link (link_text) @link)
+         (inline_link (link_destination) @font-lock-constant-face)
+         (shortcut_link (link_text) @link)])))
 
    (treesit-font-lock-rules
     :feature 'quote

--- a/test/samples/docstrings.clj
+++ b/test/samples/docstrings.clj
@@ -42,7 +42,16 @@ Don't format code this way."
     "fizz"))
 
 (defmacro fix-bug
-  "Fixes most known bugs."
+  "Fixes most known bugs.
+
+  Check markdown:
+  - [[some-function]]
+  - _emphasize_
+  - [link](https://github.com)
+  - __strong__
+  - *emphasize*
+
+  Looks good."
   [& body]
   `(try
      ~@body


### PR DESCRIPTION
Follow up https://github.com/clojure-emacs/clojure-ts-mode/pull/78

- package-lint is disabled
- added more queries for markdown syntax in the docstrings
-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
