### PR TITLE
Fix issue with fontification when markdown-inline is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#74](https://github.com/clojure-emacs/clojure-ts-mode/issues/74): Add imenu support for keywords definitions.
 - [#77](https://github.com/clojure-emacs/clojure-ts-mode/issues/77): Update grammars to the latest versions.
 - [#79](https://github.com/clojure-emacs/clojure-ts-mode/pull/79): Improve markdown highlighting in the docstrings.
+- [#60](https://github.com/clojure-emacs/clojure-ts-mode/issues/60): Fix issue with incorrect fontification, when `markdown-inline` is enabled.
 
 ## 0.2.3 (2025-03-04)
 


### PR DESCRIPTION
Many thanks to Juri Linkov <juri@linkov.net> for his assistance.

Close #60 

- Use local inline-markdown parsers for each docstring to avoid fontification of unrelated Clojure code.
- Define sexp "things" for inline markdown to improve navigation inside of the docstrings.
-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
