### PR TITLE
Implement `clojure-ts-align`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+- [#16](https://github.com/clojure-emacs/clojure-ts-mode/issues/16): Introduce `clojure-ts-align`.
+
 ## 0.3.0 (2025-04-15)
 
 - [#62](https://github.com/clojure-emacs/clojure-ts-mode/issues/62): Define `list` "thing" to improve navigation in Emacs 31.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,38 @@ should look like:
 In order to apply directory-local variables to existing buffers, they must be
 reverted.
 
+### Vertical alignment
+
+You can vertically align sexps with `C-c SPC`. For instance, typing this combo
+on the following form:
+
+```clojure
+(def my-map
+  {:a-key 1
+   :other-key 2})
+```
+
+Leads to the following:
+
+```clojure
+(def my-map
+  {:a-key     1
+   :other-key 2})
+```
+
+Forms that can be aligned vertically are configured via the following variables:
+
+- `clojure-ts-align-reader-conditionals` - align reader conditionals as if they
+  were maps.
+- `clojure-ts-align-binding-forms` - a customizable list of forms with let-like
+  bindings that can be aligned vertically.
+- `clojure-ts-align-cond-forms` - a customizable list of forms whose body
+  elements can be aligned vertically. These forms respect the block semantic
+  indentation rule (if configured) and align only the body forms, skipping N
+  special arguments.
+- `clojure-ts-align-separator` - determines whether blank lines prevent vertical
+  alignment.
+
 ### Font Locking
 
 To highlight entire rich `comment` expression with the comment font face, set

--- a/test/samples/align.clj
+++ b/test/samples/align.clj
@@ -1,0 +1,32 @@
+(ns align)
+
+(let [^long my-map {:hello  "World"   ;Hello
+                    :foo
+                    ^String (str "Foo" "Bar")
+                    :number ^long 132
+                    :zz     "hello"}
+      another      {:this ^{:hello "world"} "is"
+                    :a    #long "1234"
+                    :b    {:this   "is"
+                           :nested "map"}}])
+
+
+{:foo "bar", :baz "Hello"
+ :a   "b"    :c   "d"}
+
+
+(clojure.core/with-redefs [hello "world"
+                           foo   "bar"]
+  (println hello foo))
+
+(condp = 2
+  123   "Hello"
+  99999 "World"
+  234   nil)
+
+(let [a-long-name 10
+      b           20])
+
+
+#?(:clj  2
+   :cljs 2)


### PR DESCRIPTION
First part for #16 

The code is adapted from `clojure-mode`, but I used `treesit-*` API wherever it was appropriate and possible. The most difficult part is dealing with metadata, I left comments describing how it works.

The function is bound to `C-c SPC` in `clojure-ts-mode-map`, similar to `clojure-mode`.

I also disabled `tab-indent-mode` by default for `clojure-ts-mode`, similar to `clojure-mode`, otherwise it tries to use tabs for alignment and sometimes it looks ugly.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
