### PR TITLE
Add support for automatic aligning forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#16](https://github.com/clojure-emacs/clojure-ts-mode/issues/16): Introduce `clojure-ts-align`.
 - [#11](https://github.com/clojure-emacs/clojure-ts-mode/issues/11): Enable regex syntax highlighting.
+- [#16](https://github.com/clojure-emacs/clojure-ts-mode/issues/16): Add support for automatic aligning forms.
 
 ## 0.3.0 (2025-04-15)
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ Leads to the following:
    :other-key 2})
 ```
 
+This can also be done automatically (as part of indentation) by turning on
+`clojure-ts-align-forms-automatically`. This way it will happen whenever you
+select some code and hit `TAB`.
+
 Forms that can be aligned vertically are configured via the following variables:
 
 - `clojure-ts-align-reader-conditionals` - align reader conditionals as if they

--- a/test/samples/align.clj
+++ b/test/samples/align.clj
@@ -27,6 +27,31 @@
 (let [a-long-name 10
       b           20])
 
-
 #?(:clj  2
    :cljs 2)
+
+#?@(:clj  [2]
+    :cljs [4])
+
+(let [this-is-a-form b
+      c              d
+
+      another form
+      k       g])
+
+{:this-is-a-form b
+ c               d
+
+ :another form
+ k        g}
+
+(let [x  {:a 1
+          :b 2} ; comment
+      xx 3]
+  x)
+
+(case x
+  :a  (let [a  1
+            aa (+ a 1)]
+        aa); comment
+  :aa 2)


### PR DESCRIPTION
Close #16 

I copied all related tests from `clojure-mode` with one exception. `should handle incomplete sexps` won't work, because syntax tree will be broken.

I also found a few issues in the `clojure-ts-align` after running full `clojure-mode` test suite. All the issues are fixed now.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
