### PR TITLE
Add unwind refactoring commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Syntax highlighting of built-in keywords.
   - Consistent indentation with regular forms.
   - Support for automatic aligning forms.
+- [#88](https://github.com/clojure-emacs/clojure-ts-mode/pull/88): Introduce `clojure-ts-unwind` and `clojure-ts-unwind-all`.
 
 ## 0.3.0 (2025-04-15)
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,28 @@ following customization:
 (setopt clojure-ts-outline-variant 'imenu)
 ```
 
+## Refactoring support
+
+### Threading macros related features
+
+`clojure-unwind`: Unwind a threaded expression. Supports both `->>`/`some->>`
+and `->`/`some->`.
+
+`clojure-unwind-all`: Fully unwind a threaded expression removing the threading
+macro.
+
+### Default keybindings
+
+| Keybinding  | Command             |
+|:------------|:--------------------|
+| `C-c SPC`   | `clojure-ts-align`  |
+| `C-c C-r u` | `clojure-ts-unwind` |
+
+### Customize refactoring commands prefix
+
+By default prefix for all refactoring commands is `C-c C-r`. It can be changed
+by customizing `clojure-ts-refactor-map-prefix` variable.
+
 ## Migrating to clojure-ts-mode
 
 If you are migrating to `clojure-ts-mode` note that `clojure-mode` is still

--- a/test/clojure-ts-mode-font-lock-test.el
+++ b/test/clojure-ts-mode-font-lock-test.el
@@ -34,9 +34,9 @@
   (declare (debug t)
            (indent 1))
   `(with-clojure-ts-buffer ,content
-                           (font-lock-ensure)
-                           (goto-char (point-min))
-                           ,@body))
+     (font-lock-ensure)
+     (goto-char (point-min))
+     ,@body))
 
 (defun clojure-ts-get-face-at (start end content)
   "Get the face between START and END in CONTENT."

--- a/test/clojure-ts-mode-refactor-threading-test.el
+++ b/test/clojure-ts-mode-refactor-threading-test.el
@@ -1,0 +1,166 @@
+;;; clojure-ts-mode-refactor-threading-test.el --- clojure-ts-mode: refactor  threading tests  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Roman Rudakov
+
+;; Author: Roman Rudakov <rrudakov@fastmail.com>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; The threading refactoring code is adapted from clojure-mode.el.
+
+;;; Code:
+
+(require 'clojure-ts-mode)
+(require 'buttercup)
+(require 'test-helper "test/test-helper")
+
+(describe "clojure-unwind"
+
+  (when-refactoring-it "should unwind -> one step"
+    "(-> {}
+    (assoc :key \"value\")
+    (dissoc :lock))"
+
+    "(-> (assoc {} :key \"value\")
+    (dissoc :lock))"
+
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind -> completely"
+    "(-> {}
+    (assoc :key \"value\")
+    (dissoc :lock))"
+
+    "(dissoc (assoc {} :key \"value\") :lock)"
+
+    (clojure-ts-unwind)
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind ->> one step"
+    "(->> [1 2 3 4 5]
+     (filter even?)
+     (map square))"
+
+    "(->> (filter even? [1 2 3 4 5])
+     (map square))"
+
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind ->> completely"
+    "(->> [1 2 3 4 5]
+     (filter even?)
+     (map square))"
+
+    "(map square (filter even? [1 2 3 4 5]))"
+
+    (clojure-ts-unwind)
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind N steps with numeric prefix arg"
+    "(->> [1 2 3 4 5]
+     (filter even?)
+     (map square)
+     sum)"
+
+    "(->> (map square (filter even? [1 2 3 4 5]))
+     sum)"
+
+    (clojure-ts-unwind 2))
+
+  (when-refactoring-it "should unwind completely with universal prefix arg"
+    "(->> [1 2 3 4 5]
+     (filter even?)
+     (map square)
+     sum)"
+
+    "(sum (map square (filter even? [1 2 3 4 5])))"
+
+    (clojure-ts-unwind '(4)))
+
+  (when-refactoring-it "should unwind correctly when multiple ->> are present on same line"
+    "(->> 1 inc) (->> [1 2 3 4 5]
+     (filter even?)
+     (map square))"
+
+    "(->> 1 inc) (map square (filter even? [1 2 3 4 5]))"
+
+    (clojure-ts-unwind)
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind with function name"
+    "(->> [1 2 3 4 5]
+     sum
+     square)"
+
+    "(->> (sum [1 2 3 4 5])
+     square)"
+
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind with function name twice"
+    "(-> [1 2 3 4 5]
+     sum
+     square)"
+
+    "(square (sum [1 2 3 4 5]))"
+
+    (clojure-ts-unwind)
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should thread-issue-6-1"
+    "(defn plus [a b]
+  (-> a (+ b)))"
+
+    "(defn plus [a b]
+  (+ a b))"
+
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should thread-issue-6-2"
+    "(defn plus [a b]
+  (->> a (+ b)))"
+
+    "(defn plus [a b]
+  (+ b a))"
+
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind some->"
+    "(some-> {:a 1}
+        (find :b)
+        val
+        (+ 5))"
+
+    "(some-> (val (find {:a 1} :b))
+        (+ 5))"
+
+    (clojure-ts-unwind)
+    (clojure-ts-unwind))
+
+  (when-refactoring-it "should unwind some->>"
+    "(some->> :b
+         (find {:a 1}) val
+         (+ 5))"
+
+    "(some->> (val (find {:a 1} :b))
+         (+ 5))"
+
+    (clojure-ts-unwind)
+    (clojure-ts-unwind)))
+
+(provide 'clojure-ts-mode-refactor-threading-test)
+;;; clojure-ts-mode-refactor-threading-test.el ends here

--- a/test/clojure-ts-mode-util-test.el
+++ b/test/clojure-ts-mode-util-test.el
@@ -31,101 +31,101 @@
 (describe "clojure-ts-find-ns"
   (it "should find common namespace declarations"
     (with-clojure-ts-buffer "(ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns
     foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns foo.baz)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo.baz"))
+      (expect (clojure-ts-find-ns) :to-equal "foo.baz"))
     (with-clojure-ts-buffer "(ns ^:bar foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns ^:bar ^:baz foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo")))
+      (expect (clojure-ts-find-ns) :to-equal "foo")))
 
   (it "should find namespaces with spaces before ns form"
     (with-clojure-ts-buffer "  (ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo")))
+      (expect (clojure-ts-find-ns) :to-equal "foo")))
 
   (it "should skip namespaces within any comment forms"
     (with-clojure-ts-buffer "(comment
       (ns foo))"
-                            (expect (clojure-ts-find-ns) :to-equal nil))
+      (expect (clojure-ts-find-ns) :to-equal nil))
     (with-clojure-ts-buffer " (ns foo)
      (comment
       (ns bar))"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer " (comment
       (ns foo))
      (ns bar)
     (comment
       (ns baz))"
-                            (expect (clojure-ts-find-ns) :to-equal "bar")))
+      (expect (clojure-ts-find-ns) :to-equal "bar")))
 
   (it "should find namespace declarations with nested metadata and docstrings"
     (with-clojure-ts-buffer "(ns ^{:bar true} foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns #^{:bar true} foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns #^{:fail {}} foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns ^{:fail2 {}} foo.baz)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo.baz"))
+      (expect (clojure-ts-find-ns) :to-equal "foo.baz"))
     (with-clojure-ts-buffer "(ns ^{} foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns ^{:skip-wiki true}
       aleph.netty)"
-                            (expect (clojure-ts-find-ns) :to-equal "aleph.netty"))
+      (expect (clojure-ts-find-ns) :to-equal "aleph.netty"))
     (with-clojure-ts-buffer "(ns ^{:foo {:bar :baz} :fake (ns in.meta)} foo
   \"docstring
 (ns misleading)\")"
-                            (expect (clojure-ts-find-ns) :to-equal "foo")))
+      (expect (clojure-ts-find-ns) :to-equal "foo")))
 
   (it "should support non-alphanumeric characters"
     (with-clojure-ts-buffer "(ns foo+)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo+"))
+      (expect (clojure-ts-find-ns) :to-equal "foo+"))
     (with-clojure-ts-buffer "(ns bar**baz$-_quux)"
-                            (expect (clojure-ts-find-ns) :to-equal "bar**baz$-_quux"))
+      (expect (clojure-ts-find-ns) :to-equal "bar**baz$-_quux"))
     (with-clojure-ts-buffer "(ns aoc-2019.puzzles.day14)"
-                            (expect (clojure-ts-find-ns) :to-equal "aoc-2019.puzzles.day14")))
+      (expect (clojure-ts-find-ns) :to-equal "aoc-2019.puzzles.day14")))
 
   (it "should support in-ns forms"
     (with-clojure-ts-buffer "(in-ns 'bar.baz)"
-                            (expect (clojure-ts-find-ns) :to-equal "bar.baz")))
+      (expect (clojure-ts-find-ns) :to-equal "bar.baz")))
 
   (it "should take the first ns instead of closest unlike clojure-mode"
     (with-clojure-ts-buffer " (ns foo1)
 
 (ns foo2)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo1"))
+      (expect (clojure-ts-find-ns) :to-equal "foo1"))
     (with-clojure-ts-buffer-point " (in-ns foo1)
 (ns 'foo2)
 (in-ns 'foo3)
 |
 (ns foo4)"
-                                  (expect (clojure-ts-find-ns) :to-equal "foo3"))
+        (expect (clojure-ts-find-ns) :to-equal "foo3"))
     (with-clojure-ts-buffer "(ns foo)
 (ns-unmap *ns* 'map)
 (ns.misleading 1 2 3)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo")))
+      (expect (clojure-ts-find-ns) :to-equal "foo")))
 
   (it "should skip leading garbage"
     (with-clojure-ts-buffer " (ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "1(ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "1 (ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "1
 (ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "[1]
 (ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "[1] (ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "[1](ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns)(ns foo)"
-                            (expect (clojure-ts-find-ns) :to-equal "foo"))
+      (expect (clojure-ts-find-ns) :to-equal "foo"))
     (with-clojure-ts-buffer "(ns 'foo)(ns bar)"
-                            (expect (clojure-ts-find-ns) :to-equal "bar"))))
+      (expect (clojure-ts-find-ns) :to-equal "bar"))))

--- a/test/samples/refactoring.clj
+++ b/test/samples/refactoring.clj
@@ -1,0 +1,37 @@
+(ns refactoring)
+
+;;; Threading
+
+(-> ;; This is comment
+    (foo)
+    ;; Another comment
+    (bar true
+         ;; Hello
+         false)
+    (baz))
+
+
+(let [some (->> yeah
+                (world foo
+                       false)
+                hello)])
+
+(->> coll
+     (filter identity)
+     (map :id)
+     (map :name))
+
+(some->> coll
+         (filter identity)
+         (map :id)
+         (map :name))
+
+(defn plus [a b]
+  (-> a (+ b)))
+
+(some->> :b
+         (find {:a 1}) val
+         (+ 5))
+
+(some->> (val (find {:a 1} :b))
+         (+ 5))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -42,10 +42,10 @@ and point left there."
   (declare (indent 2))
   `(progn
      (with-clojure-ts-buffer ,text
-                             (goto-char (point-min))
-                             (re-search-forward "|")
-                             (delete-char -1)
-                             ,@body)))
+       (goto-char (point-min))
+       (re-search-forward "|")
+       (delete-char -1)
+       ,@body)))
 
 (defun clojure-ts--s-index-of (needle s &optional ignore-case)
   "Returns first index of NEEDLE in S, or nil.
@@ -108,4 +108,5 @@ Removes the temp directory at the end of evaluation."
         ,@body)
       (delete-directory ,temp-dir t))))
 
+(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The new commands work the same as in `clojure-mode` with one improvement (hopefully):

In `clojure-mode` unwinding form `(-> foo bar)` would produce `(-> (bar foo))`, so you need to run unwind command one more time to get rid of threading macro. In `clojure-ts-mode` it will produce `(bar foo)` immediately. Because of that I had to adapt tests from `clojure-mode` a little bit.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
