### PR TITLE
Introduce threading refactoring commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - Consistent indentation with regular forms.
   - Support for automatic aligning forms.
 - [#88](https://github.com/clojure-emacs/clojure-ts-mode/pull/88): Introduce `clojure-ts-unwind` and `clojure-ts-unwind-all`.
+- [#89](https://github.com/clojure-emacs/clojure-ts-mode/pull/89): Introduce `clojure-ts-thread`, `clojure-ts-thread-first-all` and
+  `clojure-ts-thread-last-all`.
 
 ## 0.3.0 (2025-04-15)
 

--- a/README.md
+++ b/README.md
@@ -376,23 +376,65 @@ following customization:
 
 ### Threading macros related features
 
+`clojure-thread`: Thread another form into the surrounding thread. Both
+`->>`/`some->>` and `->`/`some->` variants are supported.
+
 `clojure-unwind`: Unwind a threaded expression. Supports both `->>`/`some->>`
 and `->`/`some->`.
+
+`clojure-thread-first-all`: Introduce the thread first macro (`->`) and rewrite
+the entire form. With a prefix argument do not thread the last form.
+
+`clojure-thread-last-all`: Introduce the thread last macro and rewrite the
+entire form. With a prefix argument do not thread the last form.
 
 `clojure-unwind-all`: Fully unwind a threaded expression removing the threading
 macro.
 
 ### Default keybindings
 
-| Keybinding  | Command             |
-|:------------|:--------------------|
-| `C-c SPC`   | `clojure-ts-align`  |
-| `C-c C-r u` | `clojure-ts-unwind` |
+| Keybinding                  | Command                       |
+|:----------------------------|:------------------------------|
+| `C-c SPC`                   | `clojure-ts-align`            |
+| `C-c C-r t` / `C-c C-r C-t` | `clojure-ts-thread`           |
+| `C-c C-r u` / `C-c C-r C-u` | `clojure-ts-unwind`           |
+| `C-c C-r f` / `C-c C-r C-f` | `clojure-ts-thread-first-all` |
+| `C-c C-r l` / `C-c C-r C-l` | `clojure-ts-thread-last-all`  |
 
 ### Customize refactoring commands prefix
 
 By default prefix for all refactoring commands is `C-c C-r`. It can be changed
 by customizing `clojure-ts-refactor-map-prefix` variable.
+
+### Customize threading refactoring behavior
+
+By default `clojure-ts-thread-first-all` and `clojure-ts-thread-last-all` will
+thread all nested expressions. For example this expression:
+
+```clojure
+(->map (assoc {} :key "value") :lock)
+```
+
+After executing `clojure-ts-thread-last-all` will be converted to:
+
+```clojure
+(-> {}
+    (assoc :key "value")
+    (->map :lock))
+```
+
+This behavior can be changed by setting:
+
+```emacs-lisp
+(setopt clojure-ts-thread-all-but-last t)
+```
+
+Then the last expression will not be threaded and the result will be:
+
+```clojure
+(-> (assoc {} :key "value")
+    (->map :lock))
+```
 
 ## Migrating to clojure-ts-mode
 

--- a/test/samples/indentation.clj
+++ b/test/samples/indentation.clj
@@ -281,3 +281,13 @@
         user "John Doe"]
     (dotimes [_ (add x y)]
       (hello user))))
+
+(with-open [input-stream
+            ^java.io.BufferedInputStream
+            (foo bar
+                 baz
+                 true)
+
+            reader
+            (io/reader input-stream)]
+  (read-report (into [] (csv/read-csv reader))))

--- a/test/samples/refactoring.clj
+++ b/test/samples/refactoring.clj
@@ -2,6 +2,8 @@
 
 ;;; Threading
 
+;;;; Unwind
+
 (-> ;; This is comment
     (foo)
     ;; Another comment
@@ -35,3 +37,36 @@
 
 (some->> (val (find {:a 1} :b))
          (+ 5))
+
+;;;; Thread
+
+(-> (foo (bar (baz)) "arg on a separate line"))
+
+(foo (bar (baz)))
+
+(-> (foo (bar))
+    (baz))
+
+(->> (filter :active? (map :status items)))
+
+(-> (dissoc (assoc {} :key "value") :lock))
+
+
+(-> inc
+    (map [1 2]))
+
+(map
+ inc
+ [1 2])
+
+#(-> (.-value (.-target %)))
+
+(->> (range)
+     (map inc))
+
+(->> (map square (filter even? [1 2 3 4 5])))
+
+(deftask dev []
+         (comp (serve)
+               (cljs (lala)
+                     10)))


### PR DESCRIPTION
All related tests from `clojure-mode` pass except of those which "unjoin" lines, in `clojure-mode` it's implemented via text properties and doesn't work for the same expression after restarting Emacs. If it's an important feature, we can deal with that later.

I also fixed a couple of small issues with indentation and aligning forms.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
