### PR TITLE
Better handling of namespaced maps + bugfixes for `clojure-ts-align`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - [#91](https://github.com/clojure-emacs/clojure-ts-mode/pull/91): Introduce `clojure-ts-cycle-keyword-string`.
 - [#92](https://github.com/clojure-emacs/clojure-ts-mode/pull/92): Add commands to convert between collections types.
 - [#93](https://github.com/clojure-emacs/clojure-ts-mode/pull/93): Introduce `clojure-ts-add-arity`.
+- Fix an issue where `clojure-ts-align` would hang when called within an
+  expression containing ignored forms.
 
 ## 0.3.0 (2025-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@
 - [#91](https://github.com/clojure-emacs/clojure-ts-mode/pull/91): Introduce `clojure-ts-cycle-keyword-string`.
 - [#92](https://github.com/clojure-emacs/clojure-ts-mode/pull/92): Add commands to convert between collections types.
 - [#93](https://github.com/clojure-emacs/clojure-ts-mode/pull/93): Introduce `clojure-ts-add-arity`.
-- Fix an issue where `clojure-ts-align` would hang when called within an
-  expression containing ignored forms.
+- [#94](https://github.com/clojure-emacs/clojure-ts-mode/pull/94): Add indentation rules and `clojure-ts-align` support for namespaced maps.
 
 ## 0.3.0 (2025-04-15)
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -1505,7 +1505,8 @@ function literal."
     "var_quoting_lit" "sym_val_lit" "evaling_lit"
     "tagged_or_ctor_lit" "splicing_read_cond_lit"
     "derefing_lit" "quoting_lit" "syn_quoting_lit"
-    "unquote_splicing_lit" "unquoting_lit")
+    "unquote_splicing_lit" "unquoting_lit"
+    "dis_expr")
   "A regular expression that matches nodes that can be treated as s-expressions.")
 
 (defconst clojure-ts--list-nodes

--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -604,4 +604,9 @@ b |20])"
 
     "{:map      \"with\"
  :multiple \"ignored\"
- #_#_:forms \"foo\"}"))
+ #_#_:forms \"foo\"}")
+
+  (when-aligning-it "should support namespaced maps"
+    "#:hello {:world          true
+         :foo            \"bar\"
+         :some-very-long \"value\"}"))

--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -596,4 +596,12 @@ b |20])"
   :a  (let [a  1
             aa (+ a 1)]
         aa); comment
-  :aa 2)"))
+  :aa 2)")
+
+  (when-aligning-it "should work correctly when there are ignored forms"
+    "{:map  \"with\"
+ :some #_\"ignored\" \"form\"}"
+
+    "{:map      \"with\"
+ :multiple \"ignored\"
+ #_#_:forms \"foo\"}"))

--- a/test/samples/align.clj
+++ b/test/samples/align.clj
@@ -55,3 +55,10 @@
             aa (+ a 1)]
         aa); comment
   :aa 2)
+
+{:map  "with"
+ :some #_"ignored" "form"}
+
+{:map      "with"
+ :multiple "ignored"
+ #_#_:forms "foo"}

--- a/test/samples/refactoring.clj
+++ b/test/samples/refactoring.clj
@@ -89,10 +89,12 @@
 
 [1 2 3]
 
-;; TODO: Define indentation rule for `ns_map_lit`
-#:hello{:name "Roma"
- :world true}
+#:hello {:world          true
+         :foo            "bar"
+         :some-very-long "value"}
 
+{:name "Roma"
+ :foo true}
 
 (reify
   java.io.FileFilter


### PR DESCRIPTION
- `clojure-ts-align` wasn't working if the expression has ignored forms (prefixed with `#_`)
- namespaced maps were not indented properly and were not supported by `clojure-ts-align`.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
