### PR TITLE
Introduce more cycling refactoring commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#92](https://github.com/clojure-emacs/clojure-ts-mode/pull/92): Add commands to convert between collections types.
 - [#93](https://github.com/clojure-emacs/clojure-ts-mode/pull/93): Introduce `clojure-ts-add-arity`.
 - [#94](https://github.com/clojure-emacs/clojure-ts-mode/pull/94): Add indentation rules and `clojure-ts-align` support for namespaced maps.
+- Introduce `clojure-ts-cycle-conditional` and `clojure-ts-cycle-not`.
 
 ## 0.3.0 (2025-04-15)
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,11 @@ vice versa.
 - `clojure-ts-cycle-privacy`: Cycle privacy of `def`s or `defn`s. Use metadata
 explicitly with setting `clojure-ts-use-metadata-for-defn-privacy` to `t` for
 `defn`s too.
+- `clojure-ts-cycle-conditional`: Change a surrounding conditional form to its
+  negated counterpart, or vice versa (supports `if`/`if-not` and
+  `when`/`when-not`). For `if`/`if-not` also transposes the else and then
+  branches, keeping the semantics the same as before.
+- `clojure-ts-cycle-not`: Add or remove a `not` form around the current form.
 
 ### Convert collection
 
@@ -461,6 +466,8 @@ multi-arity function or macro. Function can be defined using `defn`, `fn` or
 | `C-c C-r {` / `C-c C-r C-{` | `clojure-ts-convert-collection-to-map`         |
 | `C-c C-r [` / `C-c C-r C-[` | `clojure-ts-convert-collection-to-vector`      |
 | `C-c C-r #` / `C-c C-r C-#` | `clojure-ts-convert-collection-to-set`         |
+| `C-c C-r c` / `C-c C-r C-c` | `clojure-ts-cycle-conditional`                 |
+| `C-c C-r o` / `C-c C-r C-o` | `clojure-ts-cycle-not`                         |
 | `C-c C-r a` / `C-c C-r C-a` | `clojure-ts-add-arity`                         |
 
 ### Customize refactoring commands prefix

--- a/test/clojure-ts-mode-cycling-test.el
+++ b/test/clojure-ts-mode-cycling-test.el
@@ -190,5 +190,83 @@
 
     (clojure-ts-cycle-privacy)))
 
+(describe "clojure-cycle-if"
+
+  (when-refactoring-with-point-it "should cycle inner if"
+    "(if this
+  (if |that
+    (then AAA)
+    (else BBB))
+  (otherwise CCC))"
+
+    "(if this
+  (if-not |that
+    (else BBB)
+    (then AAA))
+  (otherwise CCC))"
+
+    (clojure-ts-cycle-conditional))
+
+  (when-refactoring-with-point-it "should cycle outer if"
+    "(if-not |this
+  (if that
+    (then AAA)
+    (else BBB))
+  (otherwise CCC))"
+
+    "(if |this
+  (otherwise CCC)
+  (if that
+    (then AAA)
+    (else BBB)))"
+
+    (clojure-ts-cycle-conditional)))
+
+(describe "clojure-cycle-when"
+
+  (when-refactoring-with-point-it "should cycle inner when"
+    "(when this
+  (when |that
+    (aaa)
+    (bbb))
+  (ccc))"
+
+    "(when this
+  (when-not |that
+    (aaa)
+    (bbb))
+  (ccc))"
+
+    (clojure-ts-cycle-conditional))
+
+  (when-refactoring-with-point-it "should cycle outer when"
+    "(when-not |this
+  (when that
+    (aaa)
+    (bbb))
+  (ccc))"
+
+    "(when |this
+  (when that
+    (aaa)
+    (bbb))
+  (ccc))"
+
+    (clojure-ts-cycle-conditional)))
+
+(describe "clojure-cycle-not"
+
+  (when-refactoring-with-point-it "should add a not when missing"
+    "(ala bala| portokala)"
+    "(not (ala bala| portokala))"
+
+    (clojure-ts-cycle-not))
+
+  (when-refactoring-with-point-it "should remove a not when present"
+    "(not (ala bala| portokala))"
+    "(ala bala| portokala)"
+
+    (clojure-ts-cycle-not)))
+
 (provide 'clojure-ts-mode-cycling-test)
 ;;; clojure-ts-mode-cycling-test.el ends here

--- a/test/samples/refactoring.clj
+++ b/test/samples/refactoring.clj
@@ -134,3 +134,10 @@
   ^{:bla "meta"}
   [arg]
   body)
+
+(if ^boolean (= 2 2)
+  true
+  false)
+
+(when-not true
+  (println "Hello world"))


### PR DESCRIPTION
These are the last cycling refactoring commands.

Added:

- `clojure-ts-cycle-conditional`

- `clojure-ts-cycle-not`

`clojure-mode` has 2 separate commands: `clojure-mode-cycle-if` and `clojure-mode-cycle-when`. For `clojure-ts-mode` both functions looked almost identical, so I decided to combine them into a single command. Not sure if it's a good idea, I can split it if necessary. I choose the keybinding `C-c C-r C-c` for `clojure-ts-cycle-conditional`, we can change it as well.

Slightly adapted tests from `clojure-mode` pass successfully.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
