### PR TITLE
Define `sexp-default` thing to improve navigation in Emacs 31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#96](https://github.com/clojure-emacs/clojure-ts-mode/pull/96): Highlight function name properly in `extend-protocol` form.
 - [#96](https://github.com/clojure-emacs/clojure-ts-mode/pull/96): Add support for extend-protocol forms to `clojure-ts-add-arity` refactoring
   command.
+- [#98](https://github.com/clojure-emacs/clojure-ts-mode/pull/98): Slightly improved navigation by s-expressions for Emacs 31.
 
 ## 0.4.0 (2025-05-15)
 

--- a/test/clojure-ts-mode-navigation-test.el
+++ b/test/clojure-ts-mode-navigation-test.el
@@ -1,0 +1,89 @@
+;;; clojure-ts-mode-navigation-test.el --- Clojure[TS] Mode: code navigation test suite  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Roman Rudakov
+
+;; Author: Roman Rudakov <rrudakov@fastmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Verify that Emacs' built-in navigation commands work as expected.
+
+;;; Code:
+
+(require 'clojure-ts-mode)
+(require 'buttercup)
+(require 'test-helper "test/test-helper")
+
+(describe "function literals"
+  (describe "forward-sexp"
+    (when-refactoring-with-point-it "should navigate to a closing paren if point is before an opening paren"
+      "#|(-> (.-value (.-target %)))"
+      "#(-> (.-value (.-target %)))|"
+      (forward-sexp))
+    (when-refactoring-with-point-it "should navigate to a closing paren if point is before a # character"
+      "|#(-> (.-value (.-target %)))"
+      "#(-> (.-value (.-target %)))|"
+      (forward-sexp)))
+
+  (describe "backward-up-list"
+    (when-refactoring-with-point-it "should navigate to the beginning of a parent expression"
+      "#(-> |(.-value (.-target %)))"
+      "|#(-> (.-value (.-target %)))"
+      (backward-up-list)))
+
+  (describe "raise-sexp"
+    (when-refactoring-with-point-it "should keep balanced parenthesis"
+      "#(-> |(.-value (.-target %)))"
+      "|(.-value (.-target %))"
+      (raise-sexp))))
+
+(describe "sets"
+  (describe "forward-sexp"
+    (when-refactoring-with-point-it "should navigate to a closing paren if point is before an opening paren"
+      "#|{1 2 3}"
+      "#{1 2 3}|"
+      (forward-sexp))
+    (when-refactoring-with-point-it "should navigate to a closing paren if point is before a # character"
+      "|#{1 2 3}"
+      "#{1 2 3}|"
+      (forward-sexp)))
+
+  (describe "backward-up-list"
+    (when-refactoring-with-point-it "should navigate to the beginning of a parent expression"
+      "#{1 |2 3}"
+      "|#{1 2 3}"
+      (backward-up-list)))
+
+  (describe "raise-sexp"
+    (when-refactoring-with-point-it "should not keep unwanted characters"
+      "#{1 |2 3}"
+      "|2"
+      (raise-sexp))))
+
+(describe "nodes with metadata"
+  (describe "forward-sexp"
+    (when-refactoring-with-point-it "should navigate to a closing paren if point is before an opening paren"
+      "^String |[arg]"
+      "^String [arg]|"
+      (forward-sexp))
+    ;; This is not perfect, but with the current grammar we cannot handle it better.
+    (when-refactoring-with-point-it "should naigate to a closing paren if point is before metadata"
+      "|^String [arg]"
+      "^String [arg]|"
+      (forward-sexp))))
+
+(provide 'clojure-ts-mode-navigation-test)
+;;; clojure-ts-mode-navigation-test.el ends here

--- a/test/samples/refactoring.clj
+++ b/test/samples/refactoring.clj
@@ -76,8 +76,13 @@
 (def my-name "Roma")
 
 (defn say-hello
-  []
+  ^String []
   (println "Hello" my-name))
+
+(defn foo
+  ^{:bla "meta"}
+  [arg]
+  body)
 
 (definline bad-sqr [x] `(* ~x ~x))
 


### PR DESCRIPTION
Details here: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=78458

This PR fixes a few issues, mentioned in #97, to fix all navigation issues, the best way would be to switch to a modified grammar (see https://github.com/sogaiu/tree-sitter-clojure/issues/65).

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Issues with navigation are already mentioned in the README, including improvements in Emacs 31.

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
