### PR TITLE
Switch to experimental Clojure grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - [#96](https://github.com/clojure-emacs/clojure-ts-mode/pull/96): Highlight function name properly in `extend-protocol` form.
 - [#96](https://github.com/clojure-emacs/clojure-ts-mode/pull/96): Add support for extend-protocol forms to `clojure-ts-add-arity` refactoring
   command.
+- Improve navigation by s-expression by switching to an experimental Clojure
+  grammar.
+- More consistent docstrings highlighting and `fill-paragraph` behavior.
+- Fix bug in `clojure-ts-align` when nested form has extra spaces.
+- Fix bug in `clojure-ts-unwind` when there is only one expression after threading
+  symbol.
 
 ## 0.4.0 (2025-05-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 - [#96](https://github.com/clojure-emacs/clojure-ts-mode/pull/96): Highlight function name properly in `extend-protocol` form.
 - [#96](https://github.com/clojure-emacs/clojure-ts-mode/pull/96): Add support for extend-protocol forms to `clojure-ts-add-arity` refactoring
   command.
-- Improve navigation by s-expression by switching to an experimental Clojure
-  grammar.
-- More consistent docstrings highlighting and `fill-paragraph` behavior.
-- Fix bug in `clojure-ts-align` when nested form has extra spaces.
-- Fix bug in `clojure-ts-unwind` when there is only one expression after threading
-  symbol.
+- [#99](https://github.com/clojure-emacs/clojure-ts-mode/pull/99): Improve navigation by s-expression by switching to an experimental
+  Clojure grammar.
+- [#99](https://github.com/clojure-emacs/clojure-ts-mode/pull/99): More consistent docstrings highlighting and `fill-paragraph` behavior.
+- [#99](https://github.com/clojure-emacs/clojure-ts-mode/pull/99): Fix bug in `clojure-ts-align` when nested form has extra spaces.
+- [#99](https://github.com/clojure-emacs/clojure-ts-mode/pull/99): Fix bug in `clojure-ts-unwind` when there is only one expression after
+  threading symbol.
 
 ## 0.4.0 (2025-05-15)
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,15 @@ Once installed, evaluate `clojure-ts-mode.el` and you should be ready to go.
 > `clojure-ts-mode` install the required grammars automatically, so for most
 > people no manual actions will be required.
 
-`clojure-ts-mode` makes use of two Tree-sitter grammars to work properly:
+`clojure-ts-mode` makes use of the following Tree-sitter grammars:
 
-- The Clojure grammar, mentioned earlier
-- [markdown-inline](https://github.com/MDeiml/tree-sitter-markdown), which
-will be used for docstrings if available and if `clojure-ts-use-markdown-inline` is enabled.
+- The [experimental](https://github.com/sogaiu/tree-sitter-clojure/tree/unstable-20250526) version Clojure grammar. This version includes a few
+  improvements, which potentially will be promoted to a stable release (See [the
+  discussion](https://github.com/sogaiu/tree-sitter-clojure/issues/65)). This grammar is required for proper work of `clojure-ts-mode`.
+- [markdown-inline](https://github.com/MDeiml/tree-sitter-markdown), which will be used for docstrings if available and if
+  `clojure-ts-use-markdown-inline` is enabled.
+- [tree-sitter-regex](https://github.com/tree-sitter/tree-sitter-regex/releases/tag/v0.24.3), which will be used for regex literals if available and if
+  `clojure-ts-use-regex-parser` is not `nil`.
 
 If you have `git` and a C compiler (`cc`) available on your system's `PATH`,
 `clojure-ts-mode` will install the
@@ -136,8 +140,14 @@ set to `t` (the default).
 
 If `clojure-ts-mode` fails to automatically install the grammar, you have the
 option to install it manually, Please, refer to the installation instructions of
-each required grammar and make sure you're install the versions expected. (see
-`clojure-ts-grammar-recipes` for details)
+each required grammar and make sure you're install the versions expected (see
+`clojure-ts-grammar-recipes` for details).
+
+If `clojure-ts-ensure-grammars` is enabled, `clojure-ts-mode` will try to upgrade
+the Clojure grammar if it's outdated. This might happen, when you activate
+`clojure-ts-mode` for the first time after package update. If grammar was
+previously installed, you might need to restart Emacs, because it has to reload
+the grammar binary.
 
 ### Upgrading Tree-sitter grammars
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -371,18 +371,22 @@ Only intended for use at development time.")
   "Return a regular expression that matches one of SYMBOLS exactly."
   (concat "^" (regexp-opt symbols) "$"))
 
-(defvar clojure-ts-function-docstring-symbols
-  '("definline"
-    "defmulti"
-    "defmacro"
-    "defn"
-    "defn-"
-    "defprotocol"
-    "ns")
+(defconst clojure-ts-function-docstring-symbols
+  (eval-and-compile
+    (rx line-start
+        (or "definline"
+            "defmulti"
+            "defmacro"
+            "defn"
+            "defn-"
+            "defprotocol"
+            "ns")
+        line-end))
   "Symbols that accept an optional docstring as their second argument.")
 
-(defvar clojure-ts-definition-docstring-symbols
-  '("def")
+(defconst clojure-ts-definition-docstring-symbols
+  (eval-and-compile
+    (rx line-start "def" line-end))
   "Symbols that accept an optional docstring as their second argument.
 Any symbols added here should only treat their second argument as a docstring
 if a third argument (the value) is provided.
@@ -428,7 +432,7 @@ if a third argument (the value) is provided.
                :anchor (str_lit (str_content) ,capture-symbol) @font-lock-doc-face
                ;; The variable's value
                :anchor (_))
-     (:match ,(clojure-ts-symbol-regexp clojure-ts-definition-docstring-symbols)
+     (:match ,clojure-ts-definition-docstring-symbols
              @_def_symbol))
     ;; Captures docstrings in metadata of definitions
     ((list_lit :anchor [(comment) (meta_lit) (old_meta_lit)] :*
@@ -456,7 +460,7 @@ if a third argument (the value) is provided.
                :anchor (sym_lit)
                :anchor [(comment) (meta_lit) (old_meta_lit)] :*
                :anchor (str_lit (str_content) ,capture-symbol) @font-lock-doc-face)
-     (:match ,(clojure-ts-symbol-regexp clojure-ts-function-docstring-symbols)
+     (:match ,clojure-ts-function-docstring-symbols
              @_def_symbol))
     ;; Captures docstrings in defprotcol, definterface
     ((list_lit :anchor [(comment) (meta_lit) (old_meta_lit)] :*
@@ -1498,7 +1502,15 @@ function literal."
                                              "definline"
                                              "defrecord"
                                              "defmacro"
-                                             "defmulti")
+                                             "defmulti"
+                                             "defonce"
+                                             "defprotocol"
+                                             "deftest"
+                                             "deftest-"
+                                             "ns"
+                                             "definterface"
+                                             "deftype"
+                                             "defstruct")
                                          eol)))
 
 (defconst clojure-ts--markdown-inline-sexp-nodes
@@ -1509,7 +1521,7 @@ function literal."
 
 (defun clojure-ts--default-sexp-node-p (node)
   "Return TRUE if point is after the # marker of set or function literal NODE."
-  (and (eq (char-before (point)) ?\#)
+  (and (eq (char-before) ?\#)
        (string-match-p (rx bol (or "anon_fn_lit" "set_lit") eol)
                        (treesit-node-type (treesit-node-parent node)))))
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -470,7 +470,7 @@ if a third argument (the value) is provided.
                :*)
      (:match ,clojure-ts--interface-def-symbol-regexp @_def_symbol))))
 
-(defconst clojure-ts--match-docstring-query-compiled
+(defconst clojure-ts--match-docstring-query
   (treesit-query-compile 'clojure (clojure-ts--docstring-query '@font-lock-doc-face))
   "Precompiled query that matches a Clojure docstring.")
 
@@ -839,9 +839,14 @@ Skip the optional metadata node at pos 0 if present."
      t)))
 
 (defun clojure-ts--first-value-child (node)
-  "Return the first value child of the NODE.
+  "Returns the first value child of the given NODE.
 
-This will skip metadata and comment nodes."
+In the syntax tree, there are a few types of possible child nodes:
+unnamed standalone nodes (e.g., comments), anonymous nodes (e.g.,
+opening or closing parentheses), and named nodes.  Named nodes are
+standalone nodes that are labeled by a specific name.  The most common
+names are meta and value.  This function skips any unnamed, anonymous,
+and metadata nodes and returns the first value node."
   (treesit-node-child-by-field-name node "value"))
 
 (defun clojure-ts--symbol-matches-p (symbol-regexp node)
@@ -1363,7 +1368,7 @@ according to the rule.  If NODE is nil, use next node after BOL."
   "Match PARENT when it is a docstring node."
   (when-let* ((top-level-node (treesit-parent-until parent 'defun t))
               (result (treesit-query-capture top-level-node
-                                             clojure-ts--match-docstring-query-compiled)))
+                                             clojure-ts--match-docstring-query)))
     (seq-find (lambda (elt)
                 (and (eq (car elt) 'font-lock-doc-face)
                      (treesit-node-eq (cdr elt) parent)))
@@ -1529,6 +1534,9 @@ function literal."
   `((clojure
      (sexp ,(regexp-opt clojure-ts--sexp-nodes))
      (list ,(regexp-opt clojure-ts--list-nodes))
+     ;; `sexp-default' thing allows to fallback to the default implementation of
+     ;; `forward-sexp' function where `treesit-forward-sexp' produces undesired
+     ;; results.
      (sexp-default
       ;; For `C-M-f' in "#|(a)" or "#|{1 2 3}"
       (,(rx (or "(" "{")) . ,#'clojure-ts--default-sexp-node-p))
@@ -2469,8 +2477,13 @@ before DELIM-OPEN."
            "v0.24.3"))
   "Intended to be used as the value for `treesit-language-source-alist'.")
 
-(defun clojure-ts--grammar-outdated-p ()
-  "Return TRUE if currently installed grammar is outdated."
+(defun clojure-ts--clojure-grammar-outdated-p ()
+  "Return TRUE if currently installed grammar is outdated.
+
+This function checks if `clojure-ts-mode' is compatible with the
+currently installed grammar.  The simplest way to do this is to validate
+a query that is valid in a previous grammar version but invalid in the
+required version."
   (treesit-query-valid-p 'clojure '((sym_lit (meta_lit)))))
 
 (defun clojure-ts--ensure-grammars ()
@@ -2482,7 +2495,7 @@ before DELIM-OPEN."
                   ;; If Clojure grammar is available, but outdated, re-install
                   ;; it.
                   (and (equal grammar 'clojure)
-                       (clojure-ts--grammar-outdated-p)))
+                       (clojure-ts--clojure-grammar-outdated-p)))
           (message "Installing %s Tree-sitter grammar" grammar)
           ;; `treesit-language-source-alist' is dynamically scoped.
           ;; Binding it in this let expression allows

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -306,7 +306,7 @@ Only intended for use at development time.")
   "Syntax table for `clojure-ts-mode'.")
 
 (defconst clojure-ts--builtin-dynamic-var-regexp
-  (eval-and-compile
+  (eval-when-compile
     (concat "^"
             (regexp-opt
              '("*1" "*2" "*3" "*agent*"
@@ -323,7 +323,7 @@ Only intended for use at development time.")
             "$")))
 
 (defconst clojure-ts--builtin-symbol-regexp
-  (eval-and-compile
+  (eval-when-compile
     (concat "^"
             (regexp-opt
              '("do" "if" "let*" "var"
@@ -372,52 +372,46 @@ Only intended for use at development time.")
   (concat "^" (regexp-opt symbols) "$"))
 
 (defconst clojure-ts-function-docstring-symbols
-  (eval-and-compile
-    (rx line-start
-        (or "definline"
-            "defmulti"
-            "defmacro"
-            "defn"
-            "defn-"
-            "defprotocol"
-            "ns")
-        line-end))
+  (rx line-start
+      (or "definline"
+          "defmulti"
+          "defmacro"
+          "defn"
+          "defn-"
+          "defprotocol"
+          "ns")
+      line-end)
   "Symbols that accept an optional docstring as their second argument.")
 
 (defconst clojure-ts-definition-docstring-symbols
-  (eval-and-compile
-    (rx line-start "def" line-end))
+  (rx line-start "def" line-end)
   "Symbols that accept an optional docstring as their second argument.
 Any symbols added here should only treat their second argument as a docstring
 if a third argument (the value) is provided.
 \"def\" is the only builtin Clojure symbol that behaves like this.")
 
 (defconst clojure-ts--variable-definition-symbol-regexp
-  (eval-and-compile
-    (rx line-start (or "def" "defonce") line-end))
+  (rx line-start (or "def" "defonce") line-end)
   "A regular expression matching a symbol used to define a variable.")
 
 (defconst clojure-ts--typedef-symbol-regexp
-  (eval-and-compile
-    (rx line-start
-        (or "defprotocol" "defmulti" "deftype" "defrecord"
-            "definterface" "defmethod" "defstruct")
-        line-end))
+  (rx line-start
+      (or "defprotocol" "defmulti" "deftype" "defrecord"
+          "definterface" "defmethod" "defstruct")
+      line-end)
   "A regular expression matching a symbol used to define a type.")
 
 (defconst clojure-ts--type-symbol-regexp
-  (eval-and-compile
-    (rx line-start
-        (or "deftype" "defrecord"
-            ;; While not reifying, helps with doc strings
-            "defprotocol" "definterface"
-            "reify" "proxy" "extend-type" "extend-protocol")
-        line-end))
+  (rx line-start
+      (or "deftype" "defrecord"
+          ;; While not reifying, helps with doc strings
+          "defprotocol" "definterface"
+          "reify" "proxy" "extend-type" "extend-protocol")
+      line-end)
   "A regular expression matching a symbol used to define or instantiate a type.")
 
 (defconst clojure-ts--interface-def-symbol-regexp
-  (eval-and-compile
-    (rx line-start (or "defprotocol" "definterface") line-end))
+  (rx line-start (or "defprotocol" "definterface") line-end)
   "A regular expression matching a symbol used to define an interface.")
 
 (defun clojure-ts--docstring-query (capture-symbol)

--- a/test/clojure-ts-mode-refactor-threading-test.el
+++ b/test/clojure-ts-mode-refactor-threading-test.el
@@ -205,6 +205,13 @@
     (clojure-ts-unwind)
     (clojure-ts-unwind))
 
+  (when-refactoring-it "should work correctly when there is only one expression"
+    "(->> (filter even? [1 2 3 4]))"
+
+    "(filter even? [1 2 3 4])"
+
+    (clojure-ts-unwind))
+
   (when-refactoring-it "should unwind N steps with numeric prefix arg"
     "(->> [1 2 3 4 5]
      (filter even?)

--- a/test/samples/indentation.clj
+++ b/test/samples/indentation.clj
@@ -228,7 +228,6 @@
  :foo
  "bar"}
 
-;; NOTE: It works well now with the alternative grammar.
 '(one
   two ^:foo
   three)

--- a/test/samples/indentation.clj
+++ b/test/samples/indentation.clj
@@ -228,14 +228,24 @@
  :foo
  "bar"}
 
-;; NOTE: List elements with metadata are not indented correctly.
+;; NOTE: It works well now with the alternative grammar.
 '(one
   two ^:foo
-      three)
+  three)
 
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (defn actual
   [args])
+
+(println "Hello"
+         "World")
+
+#(println
+  "hello"
+  %)
+
+#(println "hello"
+          %)
 
 (def ^:private hello
   "World")

--- a/test/samples/navigation.clj
+++ b/test/samples/navigation.clj
@@ -1,0 +1,14 @@
+(ns navigation)
+
+(let [my-var ^{:foo "bar"} (= "Hello" "Hello")])
+
+(let [my-var ^boolean (= "Hello" "world")])
+
+#(+ % %)
+
+^boolean (= 2 2)
+
+(defn- to-string
+  ^String
+  [arg]
+  (.toString arg))


### PR DESCRIPTION
Following the https://github.com/sogaiu/tree-sitter-clojure/issues/65 discussion.

This PR contains a set of commit that accumulated while we were discussing changes in the grammar.

- Update queries to work with the new grammar. Queries are also improved to better skip comments and metadata nodes. Added support for some missing earlier forms (like `definterface`, `extend-type` etc).
- Better matching for docstrings for indentation and fill-paragraph function. Instead of defining custom functions we re-use docstring query now and check if node at point matches it.
- Fixed a minor bugs in `clojure-ts-align` + slight performance optimization by pre-compiling the query.
- Fixed a minor bug in `clojure-ts-unwind`.

This includes the changes from #98, so if this one is merged, I'll close the other one.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
