### PR TITLE
Introduce `clojure-ts-extra-def-forms` customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@
 - [#99](https://github.com/clojure-emacs/clojure-ts-mode/pull/99): Fix bug in `clojure-ts-align` when nested form has extra spaces.
 - [#99](https://github.com/clojure-emacs/clojure-ts-mode/pull/99): Fix bug in `clojure-ts-unwind` when there is only one expression after
   threading symbol.
-- Introduce `clojure-ts-jank-use-cpp-parser` customization which allows
+- [#103](https://github.com/clojure-emacs/clojure-ts-mode/issues/103): Introduce `clojure-ts-jank-use-cpp-parser` customization which allows
   highlighting C++ syntax in Jank `native/raw` forms.
-- Introduce `clojure-ts-clojurescript-use-js-parser` customization which allows
-  highlighting JS syntax in ClojureScript `js*` forms.
-
+- [#103](https://github.com/clojure-emacs/clojure-ts-mode/issues/103): Introduce `clojure-ts-clojurescript-use-js-parser` customization which
+  allows highlighting JS syntax in ClojureScript `js*` forms.
+- Introduce the `clojure-ts-extra-def-forms` customization option to specify
+  additional `defn`-like forms that should be fontified.
 
 ## 0.4.0 (2025-05-15)
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,37 @@ highlighted like regular Clojure code.
 > section](https://www.gnu.org/software/emacs/manual/html_node/emacs/Parser_002dbased-Font-Lock.html)
 > of the Emacs manual for more details.
 
+#### Extending font-lock rules
+
+In `clojure-ts-mode` it is possible to specify additional defn-like forms that
+should be fontified.  For example to highlight the following form from Hiccup
+library as a function definition:
+
+```clojure
+(defelem file-upload
+  "Creates a file upload input."
+  [name]
+  (input-field "file" name nil))
+```
+
+You can add `defelem` to `clojure-ts-extra-def-forms` list like this:
+
+```emacs-lisp
+(add-to-list 'clojure-ts-extra-def-forms "defelem")
+```
+
+or set this variable using `setopt`:
+
+```emacs-lisp
+(setopt clojure-ts-extra-def-forms '("defelem"))
+```
+
+This setting will highlight `defelem` symbol, function name and the docstring.
+
+**NOTE**: Setting `clojure-ts-extra-def-forms` won't change the indentation rule for
+these forms.  For indentation rules you should use
+`clojure-ts-semantic-indent-rules` variable (see [semantic indentation](#customizing-semantic-indentation) section).
+
 ### Highlight markdown syntax in docstrings
 
 By default Markdown syntax is highlighted in the docstrings using

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -260,6 +260,12 @@ values like this:
   :safe #'booleanp
   :type 'boolean)
 
+(defcustom clojure-ts-extra-def-forms nil
+  "List of forms that should be fontified the same way as defn."
+  :package-version '(clojure-ts-mode . "0.5")
+  :safe #'listp
+  :type '(repeat string))
+
 (defvar clojure-ts-mode-remappings
   '((clojure-mode . clojure-ts-mode)
     (clojurescript-mode . clojure-ts-clojurescript-mode)
@@ -468,6 +474,15 @@ if a third argument (the value) is provided.
                :anchor (str_lit (str_content) ,capture-symbol) @font-lock-doc-face)
      (:match ,clojure-ts-function-docstring-symbols
              @_def_symbol))
+    ((list_lit :anchor [(comment) (meta_lit) (old_meta_lit)] :*
+               :anchor (sym_lit) @_def_symbol
+               :anchor [(comment) (meta_lit) (old_meta_lit)] :*
+               ;; Function_name
+               :anchor (sym_lit)
+               :anchor [(comment) (meta_lit) (old_meta_lit)] :*
+               :anchor (str_lit (str_content) ,capture-symbol) @font-lock-doc-face)
+     (:match ,(clojure-ts-symbol-regexp clojure-ts-extra-def-forms)
+             @_def_symbol))
     ;; Captures docstrings in defprotcol, definterface
     ((list_lit :anchor [(comment) (meta_lit) (old_meta_lit)] :*
                :anchor (sym_lit) @_def_symbol
@@ -629,6 +644,12 @@ literals with regex grammar."
                         "definline"
                         "defonce")
                        eol))
+               @font-lock-keyword-face))
+      ((list_lit :anchor [(comment) (meta_lit) (old_meta_lit)] :*
+                 :anchor (sym_lit (sym_name) @font-lock-keyword-face)
+                 :anchor [(comment) (meta_lit) (old_meta_lit)] :*
+                 :anchor (sym_lit (sym_name) @font-lock-function-name-face))
+       (:match ,(clojure-ts-symbol-regexp clojure-ts-extra-def-forms)
                @font-lock-keyword-face))
       ((anon_fn_lit
         marker: "#" @font-lock-property-face))

--- a/test/clojure-ts-mode-font-lock-test.el
+++ b/test/clojure-ts-mode-font-lock-test.el
@@ -230,3 +230,22 @@ DESCRIPTION is the description of the spec."
     (set-parameter [m ^PreparedStatement s i]
       (.setObject s i (->pgobject m))))"
      (81 93 font-lock-function-name-face))))
+
+;;;; Extra def forms
+
+(describe "clojure-ts-extra-def-forms"
+  (it "should respect the value of clojure-ts-extra-def-forms"
+    (with-clojure-ts-buffer "(defelem file-upload
+  \"Creates a file upload input.\"
+  [name]
+  (input-field \"file\" name nil))"
+      (setopt clojure-ts-extra-def-forms '("defelem"))
+      (clojure-ts-mode)
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (expect (get-text-property 2 'face)
+              :to-equal 'font-lock-keyword-face)
+      (expect (get-text-property 10 'face)
+              :to-equal 'font-lock-function-name-face)
+      (expect (get-text-property 25 'face)
+              :to-equal 'font-lock-doc-face))))


### PR DESCRIPTION
Partially (or fully?) addresses #15 

In this PR I only added `clojure-ts-extra-def-forms` variable. I think we can add low-level customization if there is a request for that. For now dynamic font-lock from CIDER and this variable should cover most of the users needs.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
