### PR TITLE
Fix performance issue by pre-compiling Tree-sitter queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+- [#109](https://github.com/clojure-emacs/clojure-ts-mode/issues/109): Improve performance by pre-compiling Tree-sitter queries.
+
 ## 0.5.0 (2025-06-04)
 
 - [#96](https://github.com/clojure-emacs/clojure-ts-mode/pull/96): Highlight function name properly in `extend-protocol` form.

--- a/README.md
+++ b/README.md
@@ -591,6 +591,10 @@ and `clojure-mode` (this is very helpful when dealing with `derived-mode-p` chec
 - Navigation by sexp/lists might work differently on Emacs versions lower
   than 31. Starting with version 31, Emacs uses Tree-sitter 'things' settings, if
   available, to rebind some commands.
+- If you set `clojure-ts-extra-def-forms`, `clojure-ts-mode` will highlight the
+  specified forms, including their docstrings, in a manner similar to Clojure's
+  `defn`.  However, Markdown syntax will not be highlighted within these custom
+  docstrings.
 
 ## Frequently Asked Questions
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -207,6 +207,12 @@ metadata nodes) does not have a namespace and matches a regex stored in the
 `clojure-ts--builtin-symbol-regexp` variable.  The matched symbol is fontified
 using `font-lock-keyword-face`.
 
+> [!IMPORTANT]
+>
+> Compiling queries at runtime is very expensive; therefore, it should be
+> avoided as much as possible.  Ideally, all queries should be pre-compiled and
+> stored as `defconst` constants.
+
 ### Embedded parsers
 
 The Clojure grammar in `clojure-ts-mode` is a main or "host" grammar.  Emacs

--- a/test/samples/extra_def_forms.clj
+++ b/test/samples/extra_def_forms.clj
@@ -1,0 +1,6 @@
+(ns extra-def-forms)
+
+(defelem file-upload
+  "Creates a file upload input."
+  [name]
+  (input-field "file" name nil))


### PR DESCRIPTION
There is one trade-off: Markdown syntax won't be highlighted in docstrings of custom extra def forms.  I think it could be solved, but it would make the code more complicated.

Close #109 

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
