### PR TITLE
Set `clojure-ts-completion-at-point-function` locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## main (unreleased)
 
 - [#109](https://github.com/clojure-emacs/clojure-ts-mode/issues/109): Improve performance by pre-compiling Tree-sitter queries.
+- [#111](https://github.com/clojure-emacs/clojure-ts-mode/pull/111): Set `clojure-ts-completion-at-point-function` only for `clojure-ts-mode`
+  buffers.
 
 ## 0.5.0 (2025-06-04)
 
@@ -21,7 +23,8 @@
   allows highlighting JS syntax in ClojureScript `js*` forms.
 - [#104](https://github.com/clojure-emacs/clojure-ts-mode/pull/104): Introduce the `clojure-ts-extra-def-forms` customization option to specify
   additional `defn`-like forms that should be fontified.
-- Introduce completion feature and `clojure-ts-completion-enabled` customization.
+- [#108](https://github.com/clojure-emacs/clojure-ts-mode/pull/108): Introduce completion feature and `clojure-ts-completion-enabled`
+  customization.
 
 ## 0.4.0 (2025-05-15)
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -2858,7 +2858,8 @@ REGEX-AVAILABLE."
     (setq-local treesit-thing-settings clojure-ts--thing-settings))
 
   (when clojure-ts-completion-enabled
-    (add-to-list 'completion-at-point-functions #'clojure-ts-completion-at-point-function)))
+    (add-hook 'completion-at-point-functions
+              #'clojure-ts-completion-at-point-function nil 'local)))
 
 ;;;###autoload
 (define-derived-mode clojure-ts-mode prog-mode "Clojure[TS]"


### PR DESCRIPTION
We should use add-hook instead of add-to-list in order to set it only for clojure-ts-mode buffers.


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
<!-- - [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
