### PR TITLE
Extend completion to complete ns aliases and required symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - [#113](https://github.com/clojure-emacs/clojure-ts-mode/pull/113): Fix non-working refactoring commands for Emacs-30.
 - [#114](https://github.com/clojure-emacs/clojure-ts-mode/pull/114): Extend built-in completion to complete keywords and local bindings in
   `for` and `doseq` forms.
+- [#116](https://github.com/clojure-emacs/clojure-ts-mode/pull/116): Extend built-in completion to complete all imported symbols from an `ns`
+  form.
 
 ## 0.5.1 (2025-06-17)
 

--- a/test/clojure-ts-mode-completion.el
+++ b/test/clojure-ts-mode-completion.el
@@ -196,7 +196,33 @@ u|"
       (expect (nth 2 (clojure-ts-completion-at-point-function))
               :to-equal '((":let" . keyword-candidate)
                           ("digit" . local-candidate)
-                          ("prefixed-digit" . local-candidate))))))
+                          ("prefixed-digit" . local-candidate)))))
+
+  (it "should complete all imported symbols from a ns form"
+    (with-clojure-ts-buffer-point "
+(ns completion
+  (:require
+   [clojure.string :as str]
+   [clojure.test :as test :refer [deftest testing is]])
+  (:import
+   (java.time Instant LocalDate)))
+
+s|"
+      (expect (nth 2 (clojure-ts-completion-at-point-function))
+              :to-equal '(("completion" . defun-candidate)
+                          (":require" . keyword-candidate)
+                          (":as" . keyword-candidate)
+                          (":refer" . keyword-candidate)
+                          (":import" . keyword-candidate)
+                          (":require" . kwd)
+                          ("str" . ns-alias-candidate)
+                          ("test" . ns-alias-candidate)
+                          ("deftest" . defun-candidate)
+                          ("testing" . defun-candidate)
+                          ("is" . defun-candidate)
+                          (":import" . kwd)
+                          ("Instant" . import-candidate)
+                          ("LocalDate" . import-candidate))))))
 
 (provide 'clojure-ts-mode-completion)
 ;;; clojure-ts-mode-completion.el ends here

--- a/test/samples/completion.clj
+++ b/test/samples/completion.clj
@@ -1,4 +1,9 @@
-(ns completion)
+(ns completion
+  (:require
+   [clojure.string :as str]
+   [clojure.test :as test :refer [deftest testing is]])
+  (:import
+   (java.time Instant LocalDate)))
 
 (def my-var "Hello")
 (def my-another-var "World")


### PR DESCRIPTION
Completions for:
- namespace aliases required with `:as`
- imported functions required with `:refer`
- imported Java classes

Following up https://github.com/clojure-emacs/clojure-ts-mode/pull/114#issuecomment-2993330689

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
