### PR TITLE
Fix `clojure-ts-add-arity` bug when body has more than one expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - [#116](https://github.com/clojure-emacs/clojure-ts-mode/pull/116): Extend built-in completion to complete all imported symbols from an `ns`
   form.
 - Add documentation and bug reporting commands from `clojure-mode`.
-- Add some ns manipulation functions from `clojure-mode`.
+- [#118](https://github.com/clojure-emacs/clojure-ts-mode/pull/118): Add some ns manipulation functions from `clojure-mode`.
+- Fix a bug in `clojure-ts-add-arity` when body has more than one expression.
 
 ## 0.5.1 (2025-06-17)
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -2325,7 +2325,12 @@ type, etc.  See `treesit-thing-settings' for more details."
     (when same-line-p
       (newline-and-indent))
     (when single-arity-p
-      (insert-pair 2 ?\( ?\))
+      (save-excursion
+        (backward-up-list)
+        (forward-list)
+        (down-list -1)
+        (insert ")"))
+      (insert "(")
       (backward-up-list))
     (insert "([])\n")
     ;; Put the point between square brackets.

--- a/test/clojure-ts-mode-refactor-add-arity-test.el
+++ b/test/clojure-ts-mode-refactor-add-arity-test.el
@@ -80,6 +80,22 @@
 
     (clojure-ts-add-arity))
 
+  (when-refactoring-with-point-it "should handle a single-arity defn with multiple body expressions"
+    "(defn fo|o
+  ^{:bla \"meta\"}
+  [arg]
+  body
+  second-expr)"
+
+    "(defn foo
+  ^{:bla \"meta\"}
+  ([|])
+  ([arg]
+   body
+   second-expr))"
+
+    (clojure-ts-add-arity))
+
   (when-refactoring-with-point-it "should add an arity to a multi-arity defn"
     "(defn foo
   ([arg1])

--- a/test/samples/refactoring.clj
+++ b/test/samples/refactoring.clj
@@ -133,7 +133,8 @@
 (defn foo
   ^{:bla "meta"}
   [arg]
-  body)
+  body
+  second-expr)
 
 (if ^boolean (= 2 2)
   true


### PR DESCRIPTION
The initial implementation only worked for a single expression body.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
