### PR TITLE
Correctly indent keyword-initial lists in 'fixed' style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - [#118](https://github.com/clojure-emacs/clojure-ts-mode/pull/118): Add some ns manipulation functions from `clojure-mode`.
 - Fix a bug in `clojure-ts-add-arity` when body has more than one expression.
 - [#120](https://github.com/clojure-emacs/clojure-ts-mode/issues/120): Fix a bug when symbols with metadata were not listed in imenu.
+- [#124](https://github.com/clojure-emacs/clojure-ts-mode/issues/124): Correctly indent lists that start with a keyword when using the
+  `fixed` indentation style.
 
 ## 0.5.1 (2025-06-17)
 

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -1003,9 +1003,9 @@ If there is no namespace, returns nil."
 (defun clojure-ts--node-child-skip-metadata (node n)
   "Return the Nth child of NODE like `treesit-node-child', sans metadata.
 Skip the optional metadata node at pos 0 if present."
-  (let ((value-nodes (thread-last (treesit-node-children node t)
-                                  (seq-filter (lambda (child)
-                                                (string= (treesit-node-field-name child) "value"))))))
+  (let ((value-nodes (seq-filter (lambda (child)
+                                   (string= (treesit-node-field-name child) "value"))
+                                 (treesit-node-children node t))))
     (seq-elt value-nodes n)))
 
 (defun clojure-ts--first-value-child (node)
@@ -1213,8 +1213,7 @@ The possible values for this variable are
         (and (clojure-ts--list-node-p parent)
              ;; Should we also check for keyword first child, as in (:k map) calls?
              (let ((first-child (treesit-node-child parent 0 t)))
-               (or (clojure-ts--symbol-node-p first-child)
-                   (clojure-ts--keyword-node-p first-child)))))
+               (clojure-ts--symbol-node-p first-child))))
       parent 2)
      ((parent-is "vec_lit") parent 1)
      ((parent-is "map_lit") parent 1)


### PR DESCRIPTION
When using the 'fixed' indentation style, lists where the first element is a keyword (e.g., `(:foo ...)`) should have their children indented by a single space, per the style description.

Close #124 

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
