### PR TITLE
Fix indentation of namespaced maps in fixed style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main (unreleased)
 
+- Fix indentation of namespaced maps in `fixed` indentation style.
 - Add project root detection for ClojureCLR project.
 - Add missing `defstruct` semantic indentation rule.
 - Fix font-lock issues: duplicate query, missing `definline` metadata docstring.

--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -1219,10 +1219,11 @@ The possible values for this variable are
              (let ((first-child (treesit-node-child parent 0 t)))
                (clojure-ts--symbol-node-p first-child))))
       parent 2)
-     ((parent-is "vec_lit") parent 1)
-     ((parent-is "map_lit") parent 1)
-     ((parent-is "list_lit") parent 1)
-     ((parent-is "set_lit") parent 2))))
+     ((parent-is "^vec_lit$") parent 1)
+     ((parent-is "^map_lit$") parent 1)
+     ((parent-is "^list_lit$") parent 1)
+     ((parent-is "^set_lit$") parent 2)
+     ((parent-is "^ns_map_lit$") (nth-sibling 2) 1))))
 
 (defvar clojure-ts--semantic-indent-rules-defaults
   '(("alt!"            . ((:block 0)))

--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -399,7 +399,12 @@ DESCRIPTION is a string with the description of the spec."
    [clojure.string :as str])
   (:import
    (java.util Date
-     UUID)))"))
+     UUID)))")
+
+  (when-indenting-fixed-it "should indent namespaced maps correctly"
+    "
+#:foo{:bar 1
+      :baz 2}"))
 
 (describe "clojure-ts-align"
   (it "should handle improperly indented content"


### PR DESCRIPTION
Anchor collection node types in clojure-ts--fixed-indent-rules to avoid matching ns_map_lit, and add an explicit rule for ns_map_lit to ensure consistent indentation across styles.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [X] The commits are consistent with our [contribution guidelines][1].
<!-- - [X] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important! -->
- [X] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [X] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-ts-mode/blob/master/CONTRIBUTING.md
