### PR TITLE
Use font-lock-punctuation-face for deref @ marker

### DIFF
--- a/clojure-ts-mode.el
+++ b/clojure-ts-mode.el
@@ -806,10 +806,10 @@ and end of the NODE, so we ignore them."
           '(_ :* @font-lock-comment-face)))
       (:match "^\\(\\(clojure.core/\\)?comment\\)$" @font-lock-comment-delimiter-face)))
 
-   :feature 'deref ;; not part of clojure-mode, but a cool idea?
+   :feature 'deref
    :language 'clojure
    '((derefing_lit
-      marker: "@" @font-lock-warning-face))))
+      marker: "@" @font-lock-punctuation-face))))
 
 (defvar clojure-ts--clojure-extra-queries nil
   "Pre-compiled Tree-sitter queries produced from `clojure-ts-extra-def-forms'.")

--- a/test/clojure-ts-mode-font-lock-test.el
+++ b/test/clojure-ts-mode-font-lock-test.el
@@ -386,7 +386,7 @@ DESCRIPTION is the description of the spec."
         (clojure-ts-mode))
       (font-lock-ensure)
       (expect (get-text-property 1 'face)
-              :to-equal 'font-lock-warning-face)))
+              :to-equal 'font-lock-punctuation-face)))
 
   (it "should highlight function calls at level 4"
     (with-temp-buffer


### PR DESCRIPTION
The `@` deref marker is syntax punctuation, not a warning. Using `font-lock-warning-face` for it doesn't make much sense semantically, and warning faces tend to be bright red in many themes, which looks odd for a routine operator like deref.

`font-lock-punctuation-face` is a much better fit -- it's what tree-sitter modes typically use for syntax punctuation characters.