### PR TITLE
Call #_ forms "discard" in a test description

### DIFF
--- a/test/clojure-ts-mode-indentation-test.el
+++ b/test/clojure-ts-mode-indentation-test.el
@@ -926,7 +926,7 @@ b |20])"
         aa); comment
   :aa 2)")
 
-  (when-aligning-it "should work correctly when there are ignored forms"
+  (when-aligning-it "should work correctly when there are discard forms"
     "{:map  \"with\"
  :some #_\"ignored\" \"form\"}"
 


### PR DESCRIPTION
Tiny consistency tweak: clojure-ts-mode already uses "discard" for `#_` everywhere (README, font-lock, design doc) except one indentation-test description that said "ignored forms". Aligns it with Clojure's official terminology and the rest of the codebase. Description-only - the test data and assertions are untouched.